### PR TITLE
fix(client): add a public schema before the name of the table when the driver is postgres

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -122,7 +122,13 @@ func (c *Client) ShowTables() ([]string, error) {
 
 // TableContent returns all the rows of a table.
 func (c *Client) TableContent(tableName string) ([][]string, []string, error) {
-	query := fmt.Sprintf("SELECT * FROM %s;", tableName)
+	var query string
+
+	if c.driver == "postgres" || c.driver == "postgresql" {
+		query = fmt.Sprintf("SELECT * FROM public.%s;", tableName)
+	} else {
+		query = fmt.Sprintf("SELECT * FROM %s;", tableName)
+	}
 
 	return c.Query(query)
 }


### PR DESCRIPTION
# Public schema

## Description

When a selected table has keyword as a name, dblab stops the execution with an error. This is because an error syntax due to the use a keyword as name of a table. To fix this (at least for the postgres driver) I added the public schema as prefix of the table name.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I ran all the test suit without problems.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings