### PR TITLE
Contribution guide test steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,10 +41,38 @@ git push --set-upstream fork your-branch-name
 
 ## Running the tests
 
-Run the test suite with make.
+### Setting up the environment
+
+First of all, the repository includes a docker-compose file and a makefile. The docker file declares 4 services: a postgres container, a mysql one, a dblab container that runs migrations and seeds on the postgres container and other one that does the same for the mysql container. The makefile is used to automate some task. To spin up all the containers type:
 
 ```bash
-make test
+make up
+```
+
+Then, you'll have 2 containers up and running in your system for every kind of database supported by dblab.
+
+Run dblab openning a connection with the postgres container.
+
+```bash
+make run
+```
+
+You can do the same with the mysql container by runnning:
+
+```bash
+make run-mysql
+```
+
+Run the unit test suite with make.
+
+```bash
+make unit-test
+```
+
+Run the integration test with make too, but make sure the database containers are up and running.
+
+```bash
+make int-test
 ```
 
 This runs the tests. You can check all the options with `help` command.

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/jmoiron/sqlx v1.3.3
 	github.com/jroimartin/gocui v0.4.0
-	github.com/kkyr/fig v0.2.0 // indirect
+	github.com/kkyr/fig v0.2.0
 	github.com/lib/pq v1.10.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/muesli/termenv v0.8.1

--- a/scripts/entrypoint-mysql.dev.sh
+++ b/scripts/entrypoint-mysql.dev.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "Waiting for postgres..."
+echo "Waiting for mysql..."
 
 while ! nc -z mysql 3306; do
   sleep 0.1


### PR DESCRIPTION
# Contributing guide 

## Description

The contributing guide lacks of very important steps to get know how to set up the environment. dblab provides tools to do so, but we're not letting know to the new contributors. So, I added some points on how to set up the environment and spinning up the containers to run test against with.

## Type of change

Please delete options that are not relevant.

- [X] This change requires a documentation update

## Checklist:
- [X] I have made corresponding changes to the documentation