### PR TITLE
Default navigation menu behavior

### DIFF
--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -10,10 +10,18 @@ import (
 // nextView the app to another view.
 // the function makes sure the initial view
 // is the same as the current view in the gui.
+// Also checks if the next view is part of the hidden views.
+// If so, the function will update the navigation view.
 func nextView(from, to string) func(g *gocui.Gui, v *gocui.View) error {
 	return func(g *gocui.Gui, v *gocui.View) error {
 		if v == nil || v.Name() == from {
 			if err := switchView(g, to); err != nil {
+				return err
+			}
+		}
+
+		if contains(options, strings.Title(to)) {
+			if err := handleNavigationOptions(g, to); err == nil {
 				return err
 			}
 		}
@@ -165,6 +173,17 @@ func navigation(g *gocui.Gui, v *gocui.View) error {
 	}
 
 	return nil
+}
+
+// contains checks if a string is present in a slice.
+func contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
 }
 
 // quit is called to end the gui app.


### PR DESCRIPTION
# Default navigation menu behavior

## Description

I realized that every time that I get back to the rows section, the rows view shows up, but the navigation menu is not updated. So I decided to add a new behavior that checks if the next view is part of the navigation options. If so, the navigation menu is updated.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

QA this on my system.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
