### PR TITLE
delete the reference to the enforced column in the Constraints method

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -185,7 +185,6 @@ func (c *Client) Constraints(tableName string) ([][]string, []string, error) {
 		`tc.constraint_name`,
 		`tc.table_name`,
 		`tc.constraint_type`,
-		`tc.enforced`,
 	).
 		From("information_schema.table_constraints AS tc").
 		Where("tc.table_name = ?")


### PR DESCRIPTION
# Delete enforced column reference

## Description

The information_schema.table_constraints view doesn't have the column called enforced, so I deleted the reference to it in the client code.

Fixes #64

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I QA this by replacing the mysql docker image with a mariadb one just for testing purposes. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
