### PR TITLE
Add indexes view

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,20 +129,21 @@ Key                                     | Description
 ----------------------------------------|---------------------------------------
 <kbd>Ctrl+Space</kbd>                   | If the query panel is active, execute the query
 <kbd>Enter</kbd>                        | If the tables panel is active, list all the rows as a result set on the rows panel and display the structure of the table on the structure panel
-<kbd>Ctrl+S</kbd>                       | If the rows panel is active, switch to the schema panel
-<kbd>Ctrl+F</kbd>                       | If the rows panel is active, switch to the constraints view
-<kbd>Ctrl+h</kbd>                       | Toggle to the panel on the left
-<kbd>Ctrl+j</kbd>                       | Toggle to the panel below
-<kbd>Ctrl+k</kbd>                       | Toggle to the panel above
-<kbd>Ctrl+l</kbd>                       | Toggle to the panel on the right
-<kbd>Arrow Up</kbd>                     | Next row of the result set on the panel. Views: rows, table, constraints and structure
-<kbd>k</kbd>                            | Next row of the result set on the panel. Views: rows, table, constraints and structure
-<kbd>Arrow Down</kbd>                   | Previous row of the result set on the panel. Views: rows, table, constraints and structure
-<kbd>j</kbd>                            | Previous row of the result set on the panel. Views: rows, table, constraints and structure
-<kbd>Arrow Right</kbd>                  | Horizontal scrolling on the panel. Views: rows, constraints and structure
-<kbd>l</kbd>                            | Horizontal scrolling on the panel. Views: rows, constraints and structure
-<kbd>Arrow Left</kbd>                   | Horizontal scrolling on the panel. Views: rows, constraints and structure
-<kbd>h</kbd>                            | Horizontal scrolling on the panel. Views: rows, constraints and structure
+<kbd>Ctrl+S</kbd>                       | If the rows panel is active, switch to the schema panel. The opposite is true
+<kbd>Ctrl+F</kbd>                       | If the rows panel is active, switch to the constraints view. The opposite is true
+<kbd>Ctrl+I</kbd>                       | If the rows panel is active, switch to the indexes view. The opposite is true
+<kbd>Ctrl+H</kbd>                       | Toggle to the panel on the left
+<kbd>Ctrl+J</kbd>                       | Toggle to the panel below
+<kbd>Ctrl+K</kbd>                       | Toggle to the panel above
+<kbd>Ctrl+L</kbd>                       | Toggle to the panel on the right
+<kbd>Arrow Up</kbd>                     | Next row of the result set on the panel. Views: rows, table, constraints, structure and indexes
+<kbd>k</kbd>                            | Next row of the result set on the panel. Views: rows, table, constraints, structure and indexes
+<kbd>Arrow Down</kbd>                   | Previous row of the result set on the panel. Views: rows, table, constraints, structure and indexes
+<kbd>j</kbd>                            | Previous row of the result set on the panel. Views: rows, table, constraints, structure and indexes
+<kbd>Arrow Right</kbd>                  | Horizontal scrolling on the panel. Views: rows, constraints, structure and indexes
+<kbd>l</kbd>                            | Horizontal scrolling on the panel. Views: rows, constraints, structure and indexes
+<kbd>Arrow Left</kbd>                   | Horizontal scrolling on the panel. Views: rows, constraints, structure and indexes
+<kbd>h</kbd>                            | Horizontal scrolling on the panel. Views: rows, constraints, structure and indexes
 <kbd>Ctrl+c</kbd>                       | Quit
 
 ## Contribute

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -27,6 +27,7 @@ func New(opts command.Options) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	db, err := sqlx.Open(opts.Driver, conn)
 	if err != nil {
 		return nil, err
@@ -203,6 +204,24 @@ func (c *Client) Constraints(tableName string) ([][]string, []string, error) {
 	}
 
 	return c.Query(sql, tableName)
+}
+
+// Indexes returns a resulset with the information of the indexes given a table name.
+func (c *Client) Indexes(tableName string) ([][]string, []string, error) {
+	var query string
+
+	switch c.driver {
+	case "postgres":
+		fallthrough
+	case "postgresql":
+		query = "SELECT * FROM pg_indexes WHERE tablename = $1;"
+		return c.Query(query, tableName)
+	case "mysql":
+		query = fmt.Sprintf("SHOW INDEX FROM %s", tableName)
+		return c.Query(query)
+	default:
+		return nil, nil, errors.New("not supported driver")
+	}
 }
 
 // DB Return the db attribute.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -235,5 +235,28 @@ func TestConstraints(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Greater(t, len(r), 0)
 	assert.Greater(t, len(co), 0)
+}
 
+func TestIndexes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping short mode")
+	}
+
+	opts := command.Options{
+		Driver: driver,
+		User:   user,
+		Pass:   password,
+		Host:   host,
+		Port:   port,
+		DBName: name,
+		SSL:    "disable",
+	}
+
+	c, _ := New(opts)
+
+	r, co, err := c.Indexes("products")
+
+	assert.NoError(t, err)
+	assert.Greater(t, len(r), 0)
+	assert.Greater(t, len(co), 0)
 }

--- a/pkg/gui/database_helpers.go
+++ b/pkg/gui/database_helpers.go
@@ -161,6 +161,38 @@ func (gui *Gui) renderConstraints(g *gocui.Gui, v *gocui.View) error {
 	return nil
 }
 
+func (gui *Gui) rendexIndexes(g *gocui.Gui, v *gocui.View) error {
+	v.Rewind()
+
+	_, cy := v.Cursor()
+
+	t, err := v.Line(cy)
+	if err != nil {
+		return err
+	}
+
+	resultSet, columnNames, err := gui.c.Indexes(t)
+	if err != nil {
+		return err
+	}
+
+	ov, err := gui.g.View("indexes")
+	if err != nil {
+		return err
+	}
+
+	// Cleans the view.
+	ov.Clear()
+
+	if err := ov.SetCursor(0, 0); err != nil {
+		return err
+	}
+
+	renderTable(ov, columnNames, resultSet)
+
+	return nil
+}
+
 // metadata get the metadata from a given table name.
 func (gui *Gui) metadata(g *gocui.Gui, v *gocui.View) error {
 	if err := gui.selectTable(g, v); err != nil {
@@ -172,6 +204,10 @@ func (gui *Gui) metadata(g *gocui.Gui, v *gocui.View) error {
 	}
 
 	if err := gui.renderConstraints(g, v); err != nil {
+		return err
+	}
+
+	if err := gui.rendexIndexes(g, v); err != nil {
 		return err
 	}
 

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -70,6 +70,18 @@ func initialKeyBindings() []keyBinding {
 			handler: nextView("constraints", "query"),
 		},
 		{
+			view:    "indexes",
+			key:     gocui.KeyCtrlH,
+			mod:     gocui.ModNone,
+			handler: nextView("indexes", "tables"),
+		},
+		{
+			view:    "indexes",
+			key:     gocui.KeyCtrlK,
+			mod:     gocui.ModNone,
+			handler: nextView("indexes", "query"),
+		},
+		{
 			view:    "constraints",
 			key:     gocui.KeyCtrlF,
 			mod:     gocui.ModNone,
@@ -92,6 +104,18 @@ func initialKeyBindings() []keyBinding {
 			key:     gocui.KeyCtrlS,
 			mod:     gocui.ModNone,
 			handler: setViewOnTop("rows", "structure"),
+		},
+		{
+			view:    "indexes",
+			key:     gocui.KeyCtrlI,
+			mod:     gocui.ModNone,
+			handler: setViewOnTop("indexes", "rows"),
+		},
+		{
+			view:    "rows",
+			key:     gocui.KeyCtrlI,
+			mod:     gocui.ModNone,
+			handler: setViewOnTop("rows", "indexes"),
 		},
 		{
 			view:    "navigation",

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	green   = color.New(color.FgGreen).Add(color.Bold)
-	options = []string{"Rows", "Structure", "Constraints"}
+	options = []string{"Rows", "Structure", "Constraints", "Indexes"}
 )
 
 // Layout is called for every screen re-render e.g. when the screen is resized.
@@ -71,6 +71,16 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		if _, err := gui.g.SetCurrentView("query"); err != nil {
 			return err
 		}
+	}
+
+	if v, err := gui.g.SetView("indexes", int(0.2*float32(maxX)), int(0.29*float32(maxY)), maxX-1, int(0.95*float32(maxY))); err != nil {
+		if !errors.Is(err, gocui.ErrUnknownView) {
+			return err
+		}
+
+		v.Title = "Indexes"
+
+		fmt.Fprintln(v, "Please select a table!")
 	}
 
 	if v, err := gui.g.SetView("constraints", int(0.2*float32(maxX)), int(0.29*float32(maxY)), maxX-1, int(0.95*float32(maxY))); err != nil {


### PR DESCRIPTION
# Add indexes view

## Description

Sometimes I need to see what the indexes are on a given table, dblab lacked of this feature and still I don't know the reason why I omitted this in the first place. The solution is so similar to the previous panels: adding a new option on the navigation panel and adding the correspondent changes behind the scenes. Obviously, adding support for mysql and postgres alike. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?

I added a new test functions to validate the new query. I QA the ouput on my system.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings