### PR TITLE
Add limit by config

### DIFF
--- a/.dblab.yaml
+++ b/.dblab.yaml
@@ -5,3 +5,4 @@ database:
   password: "password"
   user: "postgres"
   driver: "postgres"
+limit: 50

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Flags:
       --driver string   Database driver
   -h, --help            help for dblab
       --host string     Server host name or IP
+      --limit int       Size of the result set from the table content query (default 100)
       --pass string     Password for user
       --port string     Server port
       --ssl string      SSL mode
@@ -83,7 +84,7 @@ You can start the app passing no flags or parameters, you'll be asked for connec
 ![Alt Text](screenshots/dblab-default-form.gif)
 
 ```sh
-$ dblab --host localhost --user myuser --db users --pass password --ssl disable --port 5432 --driver postgres
+$ dblab --host localhost --user myuser --db users --pass password --ssl disable --port 5432 --driver postgres --limit 50
 $ dblab --db path/to/file.sqlite3 --driver sqlite3
 ```
 
@@ -113,6 +114,7 @@ database:
   password: "password"
   user: "postgres"
   driver: "postgres"
+limit: 50
 ```
 
 Or for sqlite3:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ var (
 	pass   string
 	db     string
 	ssl    string
+	limit  int
 )
 
 // NewRootCmd returns the root command.
@@ -48,6 +49,7 @@ func NewRootCmd() *cobra.Command {
 					Pass:   pass,
 					DBName: db,
 					SSL:    ssl,
+					Limit:  limit,
 				}
 
 				if form.IsEmpty(opts) {
@@ -106,4 +108,5 @@ func init() {
 	rootCmd.Flags().StringVarP(&pass, "pass", "", "", "Password for user")
 	rootCmd.Flags().StringVarP(&db, "db", "", "", "Database name")
 	rootCmd.Flags().StringVarP(&ssl, "ssl", "", "", "SSL mode")
+	rootCmd.Flags().IntVarP(&limit, "limit", "", 100, "Size of the result set from the table content query")
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -21,6 +21,7 @@ import (
 type Client struct {
 	db     *sqlx.DB
 	driver string
+	limit  int
 }
 
 // New return an instance of the client.
@@ -38,6 +39,7 @@ func New(opts command.Options) (*Client, error) {
 	c := Client{
 		db:     db,
 		driver: opts.Driver,
+		limit:  opts.Limit,
 	}
 
 	return &c, nil
@@ -138,9 +140,9 @@ func (c *Client) TableContent(tableName string) ([][]string, []string, error) {
 	var query string
 
 	if c.driver == "postgres" || c.driver == "postgresql" {
-		query = fmt.Sprintf("SELECT * FROM public.%s;", tableName)
+		query = fmt.Sprintf("SELECT * FROM public.%s LIMIT %d;", tableName, c.limit)
 	} else {
-		query = fmt.Sprintf("SELECT * FROM %s;", tableName)
+		query = fmt.Sprintf("SELECT * FROM %s LIMIT %d;", tableName, c.limit)
 	}
 
 	return c.Query(query)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -156,6 +156,7 @@ func TestTableContent(t *testing.T) {
 		Port:   port,
 		DBName: name,
 		SSL:    "disable",
+		Limit:  100,
 	}
 
 	c, _ := New(opts)

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -12,6 +12,7 @@ type Options struct {
 	Pass   string
 	DBName string
 	SSL    string
+	Limit  int
 }
 
 // SetDefault returns a Options struct and fills the empty

--- a/pkg/config/.dblab.yaml
+++ b/pkg/config/.dblab.yaml
@@ -5,3 +5,4 @@ database:
   password: "password"
   user: "postgres"
   driver: "postgres"
+limit: 50

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 		Driver   string `validate:"required"`
 		SSL      string `default:"disable"`
 	}
+	Limit  int `fig:"limit" default:"100"`
 	User   string
 	Pswd   string
 	Host   string
@@ -75,6 +76,7 @@ func Init() (command.Options, error) {
 		Pass:   cfg.Database.Password,
 		DBName: cfg.Database.DB,
 		SSL:    cfg.Database.SSL,
+		Limit:  cfg.Limit,
 	}
 
 	return opts, nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -17,4 +17,5 @@ func TestInit(t *testing.T) {
 	assert.Equal(t, "postgres", opts.User)
 	assert.Equal(t, "password", opts.Pass)
 	assert.Equal(t, "postgres", opts.Driver)
+	assert.Equal(t, 50, opts.Limit)
 }


### PR DESCRIPTION
# Pull Request Template

## Description

When it comes to large or massive tables, the performance of dblab seems to be affected by the size of some result sets. That's why I came up with the idea of adding the `LIMIT` clause to the table content method query, to reduce the size of the result set dblab has to load to the memory

Fixes #86

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

I added a couple of fixes on the test suite to validate the new feature, also I QA this on my system.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my  code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
