### PR TITLE
Bugfix limit variable

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,6 @@ var (
 	pass   string
 	db     string
 	ssl    string
-	limit  int
 )
 
 // NewRootCmd returns the root command.
@@ -49,7 +48,6 @@ func NewRootCmd() *cobra.Command {
 					Pass:   pass,
 					DBName: db,
 					SSL:    ssl,
-					Limit:  limit,
 				}
 
 				if form.IsEmpty(opts) {
@@ -108,5 +106,4 @@ func init() {
 	rootCmd.Flags().StringVarP(&pass, "pass", "", "", "Password for user")
 	rootCmd.Flags().StringVarP(&db, "db", "", "", "Database name")
 	rootCmd.Flags().StringVarP(&ssl, "ssl", "", "", "SSL mode")
-	rootCmd.Flags().IntVarP(&limit, "limit", "", 100, "Size of the result set from the table content query")
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -21,7 +21,6 @@ import (
 type Client struct {
 	db     *sqlx.DB
 	driver string
-	limit  int
 }
 
 // New return an instance of the client.
@@ -39,7 +38,6 @@ func New(opts command.Options) (*Client, error) {
 	c := Client{
 		db:     db,
 		driver: opts.Driver,
-		limit:  opts.Limit,
 	}
 
 	return &c, nil

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -140,9 +140,9 @@ func (c *Client) TableContent(tableName string) ([][]string, []string, error) {
 	var query string
 
 	if c.driver == "postgres" || c.driver == "postgresql" {
-		query = fmt.Sprintf("SELECT * FROM public.%s LIMIT %d;", tableName, c.limit)
+		query = fmt.Sprintf("SELECT * FROM public.%s LIMIT 100;", tableName)
 	} else {
-		query = fmt.Sprintf("SELECT * FROM %s LIMIT %d;", tableName, c.limit)
+		query = fmt.Sprintf("SELECT * FROM %s LIMIT 100;", tableName)
 	}
 
 	return c.Query(query)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -156,7 +156,6 @@ func TestTableContent(t *testing.T) {
 		Port:   port,
 		DBName: name,
 		SSL:    "disable",
-		Limit:  100,
 	}
 
 	c, _ := New(opts)

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -12,7 +12,6 @@ type Options struct {
 	Pass   string
 	DBName string
 	SSL    string
-	Limit  int
 }
 
 // SetDefault returns a Options struct and fills the empty

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,7 +31,6 @@ type Config struct {
 		Driver   string `validate:"required"`
 		SSL      string `default:"disable"`
 	}
-	Limit  int `fig:"limit" default:"100"`
 	User   string
 	Pswd   string
 	Host   string
@@ -76,7 +75,6 @@ func Init() (command.Options, error) {
 		Pass:   cfg.Database.Password,
 		DBName: cfg.Database.DB,
 		SSL:    cfg.Database.SSL,
-		Limit:  cfg.Limit,
 	}
 
 	return opts, nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -17,5 +17,4 @@ func TestInit(t *testing.T) {
 	assert.Equal(t, "postgres", opts.User)
 	assert.Equal(t, "password", opts.Pass)
 	assert.Equal(t, "postgres", opts.Driver)
-	assert.Equal(t, 50, opts.Limit)
 }

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -29,7 +29,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		figure.Write(v, myFigure)
 	}
 
-	if v, err := gui.g.SetView("tables", 0, int(0.16*float32(maxY)), int(0.19*float32(maxX)), int(0.95*float32(maxY))); err != nil {
+	if v, err := gui.g.SetView("tables", 0, int(0.16*float32(maxY)), int(0.19*float32(maxX)), int(0.94*float32(maxY))); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
@@ -73,7 +73,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		}
 	}
 
-	if v, err := gui.g.SetView("indexes", int(0.2*float32(maxX)), int(0.29*float32(maxY)), maxX-1, int(0.95*float32(maxY))); err != nil {
+	if v, err := gui.g.SetView("indexes", int(0.2*float32(maxX)), int(0.29*float32(maxY)), maxX-1, int(0.94*float32(maxY))); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
@@ -83,7 +83,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		fmt.Fprintln(v, "Please select a table!")
 	}
 
-	if v, err := gui.g.SetView("constraints", int(0.2*float32(maxX)), int(0.29*float32(maxY)), maxX-1, int(0.95*float32(maxY))); err != nil {
+	if v, err := gui.g.SetView("constraints", int(0.2*float32(maxX)), int(0.29*float32(maxY)), maxX-1, int(0.94*float32(maxY))); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
@@ -93,7 +93,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		fmt.Fprintln(v, "Please select a table!")
 	}
 
-	if v, err := gui.g.SetView("structure", int(0.2*float32(maxX)), int(0.29*float32(maxY)), maxX-1, int(0.95*float32(maxY))); err != nil {
+	if v, err := gui.g.SetView("structure", int(0.2*float32(maxX)), int(0.29*float32(maxY)), maxX-1, int(0.94*float32(maxY))); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
@@ -103,7 +103,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		fmt.Fprintln(v, "Please select a table!")
 	}
 
-	if v, err := gui.g.SetView("rows", int(0.2*float32(maxX)), int(0.29*float32(maxY)), maxX-1, int(0.95*float32(maxY))); err != nil {
+	if v, err := gui.g.SetView("rows", int(0.2*float32(maxX)), int(0.29*float32(maxY)), maxX-1, int(0.94*float32(maxY))); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
@@ -111,6 +111,38 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		v.Title = "Rows"
 
 		fmt.Fprintln(v, "Type the sql query above. Press Ctrl-c to quit.")
+	}
+
+	if v, err := gui.g.SetView("current-page", int(0.82*float32(maxX)), int(0.96*float32(maxY)), int(0.88*float32(maxX)), int(0.99*float32(maxY))); err != nil {
+		if !errors.Is(err, gocui.ErrUnknownView) {
+			return err
+		}
+
+		fmt.Fprintln(v, "100 rows")
+	}
+
+	if v, err := gui.g.SetView("prev-page", int(0.89*float32(maxX)), int(0.96*float32(maxY)), int(0.91*float32(maxX)), int(0.99*float32(maxY))); err != nil {
+		if !errors.Is(err, gocui.ErrUnknownView) {
+			return err
+		}
+
+		fmt.Fprint(v, " < ")
+	}
+
+	if v, err := gui.g.SetView("page", int(0.92*float32(maxX)), int(0.96*float32(maxY)), int(0.97*float32(maxX)), int(0.99*float32(maxY))); err != nil {
+		if !errors.Is(err, gocui.ErrUnknownView) {
+			return err
+		}
+
+		fmt.Fprint(v, " 1 of 100 ")
+	}
+
+	if v, err := gui.g.SetView("next-page", int(0.98*float32(maxX)), int(0.96*float32(maxY)), maxX-1, int(0.99*float32(maxY))); err != nil {
+		if !errors.Is(err, gocui.ErrUnknownView) {
+			return err
+		}
+
+		fmt.Fprint(v, " > ")
 	}
 
 	return nil


### PR DESCRIPTION
# fix limit variable never empty

## Description
Accidentally left a option called `limit` which was intended to serve, as its name suggest, as limit for queries on the tables screen. Was part of a bigger plan but it never happened. The variable never was empty causing to the program never getting into the interactive mode. 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Removed that limit variable and build the program again. It got into the interactive mode successfully.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
