### PR TITLE
feat(config): draft - save first time config

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,29 +34,15 @@ func NewRootCmd() *cobra.Command {
 			var opts command.Options
 			var err error
 
-			if cfg {
-				opts, err = config.Init()
+			cfgFound, opts, err := config.Init()
+			if err != nil {
+				return err
+			}
+
+			if cfg || !cfgFound {
+				opts, err = form.Run()
 				if err != nil {
 					return err
-				}
-			} else {
-				opts = command.Options{
-					Driver: driver,
-					URL:    url,
-					Host:   host,
-					Port:   port,
-					User:   user,
-					Pass:   pass,
-					DBName: db,
-					SSL:    ssl,
-					Limit:  limit,
-				}
-
-				if form.IsEmpty(opts) {
-					opts, err = form.Run()
-					if err != nil {
-						return err
-					}
 				}
 			}
 

--- a/pkg/form/form.go
+++ b/pkg/form/form.go
@@ -2,6 +2,7 @@ package form
 
 import (
 	"fmt"
+	"github.com/danvergara/dblab/pkg/config"
 	"strconv"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -135,7 +136,7 @@ func updateDriver(msg tea.Msg, m *Model) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 
 		switch msg.String() {
-		// the "up" and "k" keys mve the cursor up.
+		// the "up" and "k" keys move the cursor up.
 		case "up", "k":
 			if m.cursor > 0 {
 				m.cursor--
@@ -179,6 +180,18 @@ func updateStd(msg tea.Msg, m *Model) (tea.Model, tea.Cmd) {
 			if s == "enter" && m.cursor == len(inputs)-1 {
 				m.steps = 2
 				m.cursor = 0
+				err := config.Write(
+					m.Host(),
+					m.driver,
+					m.Port(),
+					m.User(),
+					m.Password(),
+					m.Database(),
+					m.Limit(),
+				)
+				if err != nil {
+					return m, nil
+				}
 				return m, nil
 			}
 


### PR DESCRIPTION
# Pull Request Template

## Description

Saving the config when`dblab` is executed for the first time, or if we run `dblab` with the flag `--config`
The new config will be saved at `$HOME/.dblab.yaml`

Fixes #90 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
