### PR TITLE
Fix interactive menu sqlite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,11 @@ build:
 	CGO_ENABLED=0 \
 	go build -o dblab .
 
+.PHONY: build-sqlite3
+## build-sqlite3: Builds the Go program with CGO_ENABLED enabled.
+build-sqlite3:
+	go build -o dblab .
+
 .PHONY: run
 ## run: Runs the application
 run: build

--- a/pkg/form/form.go
+++ b/pkg/form/form.go
@@ -106,12 +106,12 @@ func (m *Model) Password() string {
 	return m.passwordInput.Value()
 }
 
-// Database returns te database name value.
+// Database returns the database name value.
 func (m *Model) Database() string {
 	return m.databaseInput.Value()
 }
 
-// SSL returns te ssl name value.
+// SSL returns the ssl name value.
 func (m *Model) SSL() string {
 	return m.ssl
 }

--- a/pkg/form/update.go
+++ b/pkg/form/update.go
@@ -1,0 +1,191 @@
+package form
+
+import (
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func updateDriver(msg tea.Msg, m *Model) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	// Is it a key press?
+	case tea.KeyMsg:
+
+		switch msg.String() {
+		// the "up" and "k" keys mve the cursor up.
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		// the "down" and "j" keys move the cursor down.
+		case "down", "j":
+			if m.cursor < len(m.drivers)-1 {
+				m.cursor++
+			}
+		case "enter":
+			driver := m.drivers[m.cursor]
+			m.driver = driver
+			m.cursor = 0
+			m.steps = 1
+			return m, nil
+		}
+	}
+
+	return m, nil
+}
+
+func updateStd(msg tea.Msg, m *Model) (tea.Model, tea.Cmd) {
+	var (
+		cmd    tea.Cmd
+		inputs []textinput.Model
+	)
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "tab", "shift+tab", "enter", "up", "down":
+			inputs = stdInputs(m)
+
+			s := msg.String()
+
+			// If so, exit.
+			if s == "enter" && m.cursor == len(inputs)-1 {
+				m.steps = 2
+				m.cursor = 0
+				return m, nil
+			}
+
+			if s == "up" || s == "shift+tab" {
+				m.cursor--
+			} else {
+				m.cursor++
+			}
+
+			if m.cursor > len(inputs) {
+				m.cursor = 0
+			} else if m.cursor < 0 {
+				m.cursor = len(inputs)
+			}
+
+			for i := 0; i <= len(inputs)-1; i++ {
+				if i == m.cursor {
+					// Set focused state.
+					inputs[i].Focus()
+					inputs[i].PromptStyle = focusedStyle
+					inputs[i].TextStyle = focusedStyle
+					continue
+				}
+				// Remove focused state.
+				inputs[i].Blur()
+				inputs[i].PromptStyle = noStyle
+				inputs[i].TextStyle = noStyle
+			}
+
+			assignStdInputValues(m, inputs)
+
+			return m, nil
+		}
+	}
+
+	m, cmd = updateInputs(msg, m)
+	return m, cmd
+}
+
+func stdInputs(m *Model) []textinput.Model {
+	var inputs []textinput.Model
+
+	if m.driver == "sqlite3" {
+		inputs = []textinput.Model{
+			m.filePathInput,
+		}
+	} else {
+		inputs = []textinput.Model{
+			m.hostInput,
+			m.portInput,
+			m.userInput,
+			m.passwordInput,
+			m.databaseInput,
+		}
+	}
+
+	inputs = append(inputs, m.limitInput)
+
+	return inputs
+}
+
+func assignStdInputValues(m *Model, inputs []textinput.Model) {
+	if m.driver == "sqlite3" && len(inputs) == 2 {
+		m.filePathInput = inputs[0]
+		m.limitInput = inputs[1]
+	} else if len(inputs) == 6 {
+		{
+			m.hostInput = inputs[0]
+			m.portInput = inputs[1]
+			m.userInput = inputs[2]
+			m.passwordInput = inputs[3]
+			m.databaseInput = inputs[4]
+			m.limitInput = inputs[5]
+		}
+	}
+}
+
+func updateSSL(msg tea.Msg, m *Model) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	// Is it a key press?
+	case tea.KeyMsg:
+
+		switch msg.String() {
+		// These keys should exit the program.
+		// the "up" and "k" keys mve the cursor up.
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		// the "down" and "j" keys move the cursor down.
+		case "down", "j":
+			if m.cursor < len(m.modes)-1 {
+				m.cursor++
+			}
+		case "enter":
+			if len(m.modes) > 0 {
+				m.ssl = m.modes[m.cursor]
+			}
+			m.steps = 3
+			m.cursor = 0
+			return m, tea.Quit
+		}
+	}
+
+	return m, nil
+}
+
+func updateInputs(msg tea.Msg, m *Model) (*Model, tea.Cmd) {
+	var (
+		cmd  tea.Cmd
+		cmds []tea.Cmd
+	)
+
+	if m.driver == "sqlite3" {
+		m.filePathInput, cmd = m.filePathInput.Update(msg)
+		cmds = append(cmds, cmd)
+	} else {
+		m.hostInput, cmd = m.hostInput.Update(msg)
+		cmds = append(cmds, cmd)
+
+		m.portInput, cmd = m.portInput.Update(msg)
+		cmds = append(cmds, cmd)
+
+		m.userInput, cmd = m.userInput.Update(msg)
+		cmds = append(cmds, cmd)
+
+		m.passwordInput, cmd = m.passwordInput.Update(msg)
+		cmds = append(cmds, cmd)
+
+		m.databaseInput, cmd = m.databaseInput.Update(msg)
+		cmds = append(cmds, cmd)
+	}
+
+	m.limitInput, cmd = m.limitInput.Update(msg)
+	cmds = append(cmds, cmd)
+
+	return m, tea.Batch(cmds...)
+}

--- a/pkg/form/view.go
+++ b/pkg/form/view.go
@@ -1,0 +1,76 @@
+package form
+
+import "fmt"
+
+func driverView(m *Model) string {
+	// The header.
+	s := "Select the database driver:"
+	var choices string
+	// Iterate over the driver.
+	for i, driver := range m.drivers {
+		choices += fmt.Sprintf("%s\n", checkbox(driver, m.cursor == i))
+	}
+
+	return fmt.Sprintf("%s\n\n%s", s, choices)
+}
+
+func standardView(m *Model) string {
+	s := "Introduce the connection params:\n\n"
+
+	inputs := viewInputs(m)
+
+	for i := 0; i < len(inputs); i++ {
+		s += inputs[i]
+		if i < len(inputs)-1 {
+			s += "\n"
+		}
+	}
+
+	s += "\n"
+	return s
+}
+
+func viewInputs(m *Model) []string {
+	var inputs []string
+
+	if m.driver == "sqlite3" {
+		inputs = []string{
+			m.filePathInput.View(),
+			m.limitInput.View(),
+		}
+	} else {
+		inputs = []string{
+			m.hostInput.View(),
+			m.portInput.View(),
+			m.userInput.View(),
+			m.passwordInput.View(),
+			m.databaseInput.View(),
+			m.limitInput.View(),
+		}
+	}
+
+	return inputs
+}
+
+func sslView(m *Model) string {
+	switch m.driver {
+	case "postgres":
+		m.modes = []string{"disable", "require", "verify-full"}
+	case "mysql":
+		m.modes = []string{"true", "false", "skip-verify", "preferred"}
+	case "sqlite3":
+		m.modes = []string{}
+	default:
+		m.modes = []string{"disable", "require", "verify-full"}
+	}
+
+	// The header.
+	s := "\nSelect the ssl mode (just press enter if you selected sqlite3):"
+	var choices string
+	// Iterate over the driver.
+	for i, mode := range m.modes {
+		choices += fmt.Sprintf("%s\n", checkbox(mode, m.cursor == i))
+	}
+
+	return fmt.Sprintf("%s\n\n%s", s, choices)
+}


### PR DESCRIPTION
# Fix interactive menu - sqlite3

## Description

The issue was originally reported by @israteneda. He pointed out that the the support for sqlite3 was missing in the interactive menu. Basically, the menu didn't ask for the path to the database file required to open a connection with the sqlite3 database. 

Fixes #94 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

We already have a database file to a sqlite3 database in the `db` directory, so once I had a working bugfix, I opened the connection with that file.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
