### PR TITLE
feat(gui): add a better feedback response at query events, the rows view sets on top

### DIFF
--- a/pkg/gui/database_helpers.go
+++ b/pkg/gui/database_helpers.go
@@ -56,6 +56,10 @@ func (gui *Gui) inputQuery() func(g *gocui.Gui, v *gocui.View) error {
 			}
 		}
 
+		if _, err := gui.g.SetViewOnTop("rows"); err != nil {
+			return err
+		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
## Description

When a user introduce a query, if the result section is not showing the `rows` view, the user may not be receiving the proper feedback on the result of their query. That's why the `rows` view needs to be set on top of the result section.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Since the gui package lacks of a proper test suite (cause it's mostly user interaction). I ran a set of different scenarios to make sure the user gets the proper feedback on the results.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
