### PR TITLE
Add sqlite binary docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ application to work with local or remote PostgreSQL/MySQL/SQLite3 databases.
 
 - Cross-platform support OSX/Linux/Windows 32/64-bit
 - Simple installation (distributed as a single binary)
-- Zero dependencies
+- Zero dependencies (except for the SQLite3 binary with CGO enabled).
 
 ## Installation
+
+> if you need to work with SQLite3, install the CGO enabled binary using the proper bash script listed below
 
 ### Homebrew
 
@@ -41,13 +43,22 @@ $ brew install dblab
 ### Binary Release (Linux/OSX/Windows)
 You can manually download a binary release from [the release page](https://github.com/danvergara/dblab/releases).
 
-Automated install/update, don't forget to always verify what you're piping into bash:
+## Automated install/update
+> Don't forget to always verify what you're piping into bash
+
+Ordinary binary:
 
 ```sh
 curl https://raw.githubusercontent.com/danvergara/dblab/master/scripts/install_update_linux.sh | bash
 ```
 
-The script installs downloaded binary to `/usr/local/bin` directory by default, but it can be changed by setting `DIR` environment variable.
+CGO enabled binary:
+
+```sh
+curl https://raw.githubusercontent.com/danvergara/dblab/master/scripts/install_update_sqlite_linux.sh | bash
+```
+
+The scripts install the binary in `/usr/local/bin` directory by default, but it can be changed by setting the `DIR` environment variable.
 
 ## Help
 

--- a/scripts/install_update_sqlite_linux.sh
+++ b/scripts/install_update_sqlite_linux.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# allow specifying different destination directory
+DIR="${DIR:-"/usr/local/bin"}"
+
+# get the OS
+OS=$(uname -s)
+case $OS in
+    Linux) OS=linux ;;
+    Darwin) OS=darwin ;;
+esac
+
+# map different architecture variations to the available binaries
+ARCH=$(uname -m)
+case $ARCH in
+    i386|i686|x86_64) ARCH=amd64 ;;
+    armv6*) ARCH=armv6 ;;
+    armv7*) ARCH=armv7 ;;
+    aarch64*) ARCH=arm64 ;;
+esac
+
+# prepare the download URL
+GITHUB_LATEST_VERSION=$(curl -L -s -H 'Accept: application/json' https://github.com/danvergara/dblab/releases/latest | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+GITHUB_FILE="dblab_${GITHUB_LATEST_VERSION//v/}_${OS}_${ARCH}.tar.gz"
+GITHUB_URL="https://github.com/danvergara/dblab/releases/download/${GITHUB_LATEST_VERSION}/${GITHUB_FILE}"
+
+echo $GITHUB_FILE
+echo $GITHUB_LATEST_VERSION
+echo $GITHUB_URL
+
+# install/update the local binary
+curl -L -o dblab.tar.gz $GITHUB_URL
+tar xzvf dblab.tar.gz
+sudo mv -f dblab-sqlite "$DIR"
+rm dblab.tar.gz


### PR DESCRIPTION
# Add sqlite binary docs

## Description

A user reported a problem with the binary failing due to the need to enable CGO at the building time, but that problem is already fixed and an special binary is getting issue at every release. I forgot to add this information properly in the docs.

Fixes #111

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

The new information added was tested against a  [grammar checker website](https://quillbot.com/grammar-check).
A new script was added to the project, so that users can install the correspondent binary. The script was tested against my local system, successfully installing the proper binary (wondering if we need to add a test suite for bash scripts).

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
