### PR TITLE
fix(goreleaser): fix the naming of the zip file for the sqlite binaries

### DIFF
--- a/.goreleaser-for-darwin.yaml
+++ b/.goreleaser-for-darwin.yaml
@@ -11,5 +11,7 @@ builds:
     goarch:
       - amd64
       - arm64
+archives:
+  - name_template: "{{ .ProjectName }}_sqlite_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 snapshot:
   name_template: "{{ .Tag }}-next"

--- a/.goreleaser-for-linux.yaml
+++ b/.goreleaser-for-linux.yaml
@@ -20,5 +20,7 @@ builds:
         goarch: amd64
         env:
           - CC=gcc
+archives:
+  - name_template: "{{ .ProjectName }}_sqlite_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 snapshot:
   name_template: "{{ .Tag }}-next"

--- a/.goreleaser-for-windows.yaml
+++ b/.goreleaser-for-windows.yaml
@@ -11,5 +11,7 @@ builds:
       - windows
     goarch:
       - amd64
+archives:
+  - name_template: "{{ .ProjectName }}_sqlite_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 snapshot:
   name_template: "{{ .Tag }}-next"


### PR DESCRIPTION
# Pull Request Template

## Description
CGO enabled binaries get the same zip file name when they get compressed. I changed the default name, thus we can have different release compressed files.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
