### PR TITLE
Fix UI resizing 

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -170,6 +170,14 @@ func (c *Client) Metadata(tableName string) (*Metadata, error) {
 	return &m, nil
 }
 
+func (c *Client) TotalPages() int {
+	if c.paginationManager != nil {
+		return c.paginationManager.TotalPages()
+	}
+
+	return 0
+}
+
 // ShowTables list all the tables in the database on the tables panel.
 func (c *Client) ShowTables() ([]string, error) {
 	var query string

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -98,8 +98,13 @@ func (c *Client) Query(q string, args ...interface{}) ([][]string, []string, err
 
 // Table represents a SQL table.
 type Table struct {
+	name    string
 	Rows    [][]string
 	Columns []string
+}
+
+func (t *Table) Name() string {
+	return t.name
 }
 
 // Metadata sums up the most relevant data from a table.
@@ -238,6 +243,7 @@ func (c *Client) NextPage() (*Table, int, error) {
 	}
 
 	t := Table{
+		name:    c.paginationManager.CurrentTable(),
 		Rows:    r,
 		Columns: col,
 	}
@@ -259,6 +265,7 @@ func (c *Client) PreviousPage() (*Table, int, error) {
 	}
 
 	t := Table{
+		name:    c.paginationManager.CurrentTable(),
 		Rows:    r,
 		Columns: col,
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -340,3 +340,29 @@ func TestMetadata(t *testing.T) {
 	assert.Len(t, m.TableContent.Rows, opts.Limit)
 	assert.Len(t, m.TableContent.Columns, 3)
 }
+
+func TestTotalPages(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping short mode")
+	}
+
+	opts := command.Options{
+		Driver: driver,
+		User:   user,
+		Pass:   password,
+		Host:   host,
+		Port:   port,
+		DBName: name,
+		SSL:    "disable",
+		Limit:  100,
+	}
+
+	c, _ := New(opts)
+
+	_, err := c.Metadata("products")
+
+	assert.NoError(t, err)
+
+	// Total count.
+	assert.Equal(t, c.TotalPages(), 1)
+}

--- a/pkg/gui/database_helpers.go
+++ b/pkg/gui/database_helpers.go
@@ -26,10 +26,7 @@ func (gui *Gui) inputQuery() func(g *gocui.Gui, v *gocui.View) error {
 			return err
 		}
 
-		if err := gui.showLabelContent("total-pages", 1); err != nil {
-			return err
-		}
-		if err := gui.showLabelContent("current-page", 1); err != nil {
+		if err := gui.showIndex("index", 1, 1); err != nil {
 			return err
 		}
 
@@ -97,11 +94,7 @@ func (gui *Gui) metadata(g *gocui.Gui, v *gocui.View) error {
 		}
 	}
 
-	// initial state of navigation label widgets.
-	if err := gui.showLabelContent("total-pages", m.TotalPages); err != nil {
-		return err
-	}
-	if err := gui.showLabelContent("current-page", 1); err != nil {
+	if err := gui.showIndex("index", 1, m.TotalPages); err != nil {
 		return err
 	}
 	return nil
@@ -167,7 +160,7 @@ func (gui *Gui) render(
 	return nil
 }
 
-func (gui *Gui) showLabelContent(viewName string, value int) error {
+func (gui *Gui) showIndex(viewName string, count, total int) error {
 	v, err := gui.g.View(viewName)
 	if err != nil {
 		return err
@@ -176,7 +169,7 @@ func (gui *Gui) showLabelContent(viewName string, value int) error {
 	// Cleans the view.
 	v.Clear()
 
-	fmt.Fprintf(v, "%4d", value)
+	fmt.Fprintf(v, "%4d / %4d", count, total)
 
 	return nil
 }
@@ -193,9 +186,15 @@ func (gui *Gui) nextPage(g *gocui.Gui, v *gocui.View) error {
 		return err
 	}
 
-	if err := gui.showLabelContent("current-page", page); err != nil {
+	totalPages := gui.c.TotalPages()
+	if err != nil {
 		return err
 	}
+
+	if err := gui.showIndex("index", page, totalPages); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -211,7 +210,12 @@ func (gui *Gui) previousPage(g *gocui.Gui, v *gocui.View) error {
 		return err
 	}
 
-	if err := gui.showLabelContent("current-page", page); err != nil {
+	totalPages := gui.c.TotalPages()
+	if err != nil {
+		return err
+	}
+
+	if err := gui.showIndex("index", page, totalPages); err != nil {
 		return err
 	}
 

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -97,39 +97,25 @@ func (gui *Gui) setLayout() {
 	)
 
 	// labels.
-	currentPage := NewLabelWidget(
-		"current-page",
-		0.84,
+	index := NewLabelWidget(
+		"index",
+		9,
 		0.96,
-		fmt.Sprintf("%4d", 0),
-		gocui.ColorWhite,
-	)
-	slash := NewLabelWidget(
-		"slash",
-		0.87,
-		0.96,
-		"/",
-		gocui.ColorWhite,
-	)
-	totalPages := NewLabelWidget(
-		"total-pages",
-		0.89,
-		0.96,
-		fmt.Sprintf("%4d", 0),
+		fmt.Sprintf("%4d / %4d", 0, 0),
 		gocui.ColorWhite,
 	)
 
 	// buttons.
 	back := NewButtonWidget(
 		"back",
-		0.80,
+		0,
 		0.96,
 		"< BACK",
 		gocui.ColorGreen,
 	)
 	next := NewButtonWidget(
 		"next",
-		0.92,
+		23,
 		0.96,
 		"NEXT >",
 		gocui.ColorGreen,
@@ -145,9 +131,7 @@ func (gui *Gui) setLayout() {
 		structure,
 		rows,
 		back,
-		currentPage,
-		slash,
-		totalPages,
+		index,
 		next,
 	)
 }

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -13,26 +13,141 @@ var (
 )
 
 func (gui *Gui) setLayout() {
-	maxX, maxY := gui.g.Size()
+	// banners.
+	banner := NewBannerWidget(
+		"banner",
+		0,
+		0,
+		0.19,
+		0.14,
+		"dblab",
+		gocui.ColorMagenta,
+	)
 
-	banner := NewBannerWidget("banner", 0, 0, int(0.19*float32(maxX)), int(0.14*float32(maxY)), "dblab", gocui.ColorMagenta)
+	// table.
+	tables := NewTableWidget(
+		"tables",
+		0,
+		0.16,
+		0.19,
+		0.94,
+		"Tables",
+		gocui.ColorGreen,
+		gocui.ColorBlack,
+		gui,
+	)
 
-	tables := NewTableWidget("tables", 0, int(0.16*float32(maxY)), int(0.19*float32(maxX)), int(0.94*float32(maxY)), "Tables", gocui.ColorGreen, gocui.ColorBlack, gui)
+	// navigation widget.
+	navigation := NewNavigationWidget(
+		"navigation",
+		0.2,
+		0,
+		-1,
+		0.07,
+		"Navigation",
+		options,
+	)
 
-	navigation := NewNavigationWidget("navigation", int(0.2*float32(maxX)), 0, maxX-1, int(0.07*float32(maxY)), "Navigation", options)
+	// editor.
+	editor := NewEditorWidget(
+		"query",
+		0.2,
+		0.09,
+		-1,
+		0.27,
+		"SQL Query",
+	)
 
-	editor := NewEditorWidget("query", int(0.2*float32(maxX)), int(0.09*float32(maxY)), maxX-1, int(0.27*float32(maxY)), "SQL Query")
-	indexes := NewOutputWidget("indexes", int(0.2*float32(maxX)), int(0.29*float32(maxY)), maxX-1, int(0.94*float32(maxY)), "Indexes", "Please select a table!")
-	constraints := NewOutputWidget("constraints", int(0.2*float32(maxX)), int(0.29*float32(maxY)), maxX-1, int(0.94*float32(maxY)), "Constraints", "Please select a table!")
-	structure := NewOutputWidget("structure", int(0.2*float32(maxX)), int(0.29*float32(maxY)), maxX-1, int(0.94*float32(maxY)), "Structure", "Please select a table!")
-	rows := NewOutputWidget("rows", int(0.2*float32(maxX)), int(0.29*float32(maxY)), maxX-1, int(0.94*float32(maxY)), "Rows", "Type the sql query above. Press Ctrl-c to quit.")
+	// outputs.
+	indexes := NewOutputWidget(
+		"indexes",
+		0.2,
+		0.29,
+		-1,
+		0.94,
+		"Indexes",
+		"Please select a table!",
+	)
+	constraints := NewOutputWidget(
+		"constraints",
+		0.2,
+		0.29,
+		-1,
+		0.94,
+		"Constraints",
+		"Please select a table!",
+	)
+	structure := NewOutputWidget(
+		"structure",
+		0.2,
+		0.29,
+		-1,
+		0.94,
+		"Structure",
+		"Please select a table!",
+	)
+	rows := NewOutputWidget(
+		"rows",
+		0.2,
+		0.29,
+		-1,
+		0.94,
+		"Rows",
+		"Type the sql query above. Press Ctrl-c to quit.",
+	)
 
-	currentPage := NewLabelWidget("current-page", int(0.84*float32(maxX)), int(0.96*float32(maxY)), fmt.Sprintf("%4d", 0), gocui.ColorWhite)
-	slash := NewLabelWidget("slash", int(0.87*float32(maxX)), int(0.96*float32(maxY)), "/", gocui.ColorWhite)
-	totalPages := NewLabelWidget("total-pages", int(0.89*float32(maxX)), int(0.96*float32(maxY)), fmt.Sprintf("%4d", 0), gocui.ColorWhite)
+	// labels.
+	currentPage := NewLabelWidget(
+		"current-page",
+		0.84,
+		0.96,
+		fmt.Sprintf("%4d", 0),
+		gocui.ColorWhite,
+	)
+	slash := NewLabelWidget(
+		"slash",
+		0.87,
+		0.96,
+		"/",
+		gocui.ColorWhite,
+	)
+	totalPages := NewLabelWidget(
+		"total-pages",
+		0.89,
+		0.96,
+		fmt.Sprintf("%4d", 0),
+		gocui.ColorWhite,
+	)
 
-	back := NewButtonWidget("back", int(0.80*float32(maxX)), int(0.96*float32(maxY)), "< BACK", gocui.ColorGreen)
-	next := NewButtonWidget("next", int(0.92*float32(maxX)), int(0.96*float32(maxY)), "NEXT >", gocui.ColorGreen)
+	// buttons.
+	back := NewButtonWidget(
+		"back",
+		0.80,
+		0.96,
+		"< BACK",
+		gocui.ColorGreen,
+	)
+	next := NewButtonWidget(
+		"next",
+		0.92,
+		0.96,
+		"NEXT >",
+		gocui.ColorGreen,
+	)
 
-	gui.g.SetManager(banner, tables, navigation, editor, indexes, constraints, structure, rows, back, currentPage, slash, totalPages, next)
+	gui.g.SetManager(
+		banner,
+		tables,
+		navigation,
+		editor,
+		indexes,
+		constraints,
+		structure,
+		rows,
+		back,
+		currentPage,
+		slash,
+		totalPages,
+		next,
+	)
 }

--- a/pkg/gui/widgets.go
+++ b/pkg/gui/widgets.go
@@ -26,9 +26,9 @@ func NewButtonWidget(name string, x, y float32, label string, color gocui.Attrib
 
 // Layout implements the gocui.Manager interface.
 func (w *ButtonWidget) Layout(g *gocui.Gui) error {
-	maxX, maxY := g.Size()
+	_, maxY := g.Size()
 
-	x := int(w.x * float32(maxX))
+	x := int(w.x)
 	y := int(w.y * float32(maxY))
 
 	v, err := g.SetView(w.name, x, y, x+w.w, y+2)
@@ -49,22 +49,23 @@ func (w *ButtonWidget) Layout(g *gocui.Gui) error {
 // x and y work as factor to determine the widget size. Since the terminal's size is retrieved in the Layout method, using a fixed coordinates is not needed.
 type LabelWidget struct {
 	name  string
-	x, y  float32
+	x     int
+	y     float32
 	w     int
 	color gocui.Attribute
 	label string
 }
 
 // NewLabelWidget returns a pointer to a LabelWidget instance.
-func NewLabelWidget(name string, x, y float32, label string, color gocui.Attribute) *LabelWidget {
+func NewLabelWidget(name string, x int, y float32, label string, color gocui.Attribute) *LabelWidget {
 	return &LabelWidget{name: name, x: x, y: y, w: len(label) + 1, label: label, color: color}
 }
 
 // Layout implements the gocui.Manager interface.
 func (w *LabelWidget) Layout(g *gocui.Gui) error {
-	maxX, maxY := g.Size()
+	_, maxY := g.Size()
 
-	x := int(w.x * float32(maxX))
+	x := w.x
 	y := int(w.y * float32(maxY))
 
 	v, err := g.SetView(w.name, x, y, x+w.w, y+2)

--- a/pkg/gui/widgets.go
+++ b/pkg/gui/widgets.go
@@ -10,22 +10,28 @@ import (
 )
 
 // ButtonWidget struct used to build buttons.
+// x and y work as factor to determine the widget size, since the terminal's size is retrieved in the Layout method.
 type ButtonWidget struct {
 	name  string
-	x, y  int
+	x, y  float32
 	w     int
 	color gocui.Attribute
 	label string
 }
 
 // NewButtonWidget returns a pointer to a ButtonWidget instance.
-func NewButtonWidget(name string, x, y int, label string, color gocui.Attribute) *ButtonWidget {
+func NewButtonWidget(name string, x, y float32, label string, color gocui.Attribute) *ButtonWidget {
 	return &ButtonWidget{name: name, x: x, y: y, w: len(label) + 1, label: label, color: color}
 }
 
 // Layout implements the gocui.Manager interface.
 func (w *ButtonWidget) Layout(g *gocui.Gui) error {
-	v, err := g.SetView(w.name, w.x, w.y, w.x+w.w, w.y+2)
+	maxX, maxY := g.Size()
+
+	x := int(w.x * float32(maxX))
+	y := int(w.y * float32(maxY))
+
+	v, err := g.SetView(w.name, x, y, x+w.w, y+2)
 	if err != nil {
 		if err != gocui.ErrUnknownView {
 			return err
@@ -40,22 +46,28 @@ func (w *ButtonWidget) Layout(g *gocui.Gui) error {
 }
 
 // LabelWidget struct used to display data to dynamic data to the user.
+// x and y work as factor to determine the widget size. Since the terminal's size is retrieved in the Layout method, using a fixed coordinates is not needed.
 type LabelWidget struct {
 	name  string
-	x, y  int
+	x, y  float32
 	w     int
 	color gocui.Attribute
 	label string
 }
 
 // NewLabelWidget returns a pointer to a LabelWidget instance.
-func NewLabelWidget(name string, x, y int, label string, color gocui.Attribute) *ButtonWidget {
-	return &ButtonWidget{name: name, x: x, y: y, w: len(label) + 1, label: label, color: color}
+func NewLabelWidget(name string, x, y float32, label string, color gocui.Attribute) *LabelWidget {
+	return &LabelWidget{name: name, x: x, y: y, w: len(label) + 1, label: label, color: color}
 }
 
 // Layout implements the gocui.Manager interface.
 func (w *LabelWidget) Layout(g *gocui.Gui) error {
-	v, err := g.SetView(w.name, w.x, w.y, w.x+w.w, w.y+2)
+	maxX, maxY := g.Size()
+
+	x := int(w.x * float32(maxX))
+	y := int(w.y * float32(maxY))
+
+	v, err := g.SetView(w.name, x, y, x+w.w, y+2)
 	if err != nil {
 		if err != gocui.ErrUnknownView {
 			return err
@@ -73,19 +85,26 @@ func (w *LabelWidget) Layout(g *gocui.Gui) error {
 // we show the name of the app.
 type BannerWidget struct {
 	name           string
-	x0, y0, x1, y1 int
+	x0, y0, x1, y1 float32
 	color          gocui.Attribute
 	label          string
 }
 
 // NewBannerWidget returns a pointer to a BannerWidget instance.
-func NewBannerWidget(name string, x0, y0, x1, y1 int, label string, color gocui.Attribute) *BannerWidget {
+func NewBannerWidget(name string, x0, y0, x1, y1 float32, label string, color gocui.Attribute) *BannerWidget {
 	return &BannerWidget{name: name, x0: x0, y0: y0, x1: x1, y1: y1, label: label, color: color}
 }
 
 // Layout implements the gocui.Manager interface.
 func (w *BannerWidget) Layout(g *gocui.Gui) error {
-	if v, err := g.SetView(w.name, w.x0, w.y0, w.x1, w.y1); err != nil {
+	maxX, maxY := g.Size()
+
+	x0 := int(w.x0 * float32(maxX))
+	y0 := int(w.y0 * float32(maxY))
+	x1 := int(w.x1 * float32(maxX))
+	y1 := int(w.y1 * float32(maxY))
+
+	if v, err := g.SetView(w.name, x0, y0, x1, y1); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
@@ -102,14 +121,14 @@ func (w *BannerWidget) Layout(g *gocui.Gui) error {
 // sql tables content.
 type TableWidget struct {
 	name             string
-	x0, y0, x1, y1   int
+	x0, y0, x1, y1   float32
 	gui              *Gui
 	bgcolor, fgcolor gocui.Attribute
 	label            string
 }
 
 // NewTableWidget returns a pointer to a TableWidget instance.
-func NewTableWidget(name string, x0, y0, x1, y1 int, label string, bgcolor, fgcolor gocui.Attribute, gui *Gui) *TableWidget {
+func NewTableWidget(name string, x0, y0, x1, y1 float32, label string, bgcolor, fgcolor gocui.Attribute, gui *Gui) *TableWidget {
 	return &TableWidget{
 		name:    name,
 		x0:      x0,
@@ -125,7 +144,14 @@ func NewTableWidget(name string, x0, y0, x1, y1 int, label string, bgcolor, fgco
 
 // Layout implements the gocui.Manager interface.
 func (w *TableWidget) Layout(g *gocui.Gui) error {
-	if v, err := g.SetView(w.name, w.x0, w.y0, w.x1, w.y1); err != nil {
+	maxX, maxY := g.Size()
+
+	x0 := int(w.x0 * float32(maxX))
+	y0 := int(w.y0 * float32(maxY))
+	x1 := int(w.x1 * float32(maxX))
+	y1 := int(w.y1 * float32(maxY))
+
+	if v, err := g.SetView(w.name, x0, y0, x1, y1); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
@@ -146,19 +172,26 @@ func (w *TableWidget) Layout(g *gocui.Gui) error {
 // NavigationWidget struct used to show the navigation panel.
 type NavigationWidget struct {
 	name           string
-	x0, y0, x1, y1 int
+	x0, y0, x1, y1 float32
 	options        []string
 	label          string
 }
 
 // NewNavigationWidget returns a pointer to a NavigationWidget instance.
-func NewNavigationWidget(name string, x0, y0, x1, y1 int, label string, options []string) *NavigationWidget {
+func NewNavigationWidget(name string, x0, y0, x1, y1 float32, label string, options []string) *NavigationWidget {
 	return &NavigationWidget{name: name, x0: x0, y0: y0, x1: x1, y1: y1, label: label, options: options}
 }
 
 // Layout implements the gocui.Manager interface.
 func (w *NavigationWidget) Layout(g *gocui.Gui) error {
-	if v, err := g.SetView(w.name, w.x0, w.y0, w.x1, w.y1); err != nil {
+	maxX, maxY := g.Size()
+
+	x0 := int(w.x0 * float32(maxX))
+	y0 := int(w.y0 * float32(maxY))
+	x1 := int(w.x1 + float32(maxX))
+	y1 := int(w.y1 * float32(maxY))
+
+	if v, err := g.SetView(w.name, x0, y0, x1, y1); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
@@ -178,18 +211,25 @@ func (w *NavigationWidget) Layout(g *gocui.Gui) error {
 // EditorWidget struct used as an editor to perform queries to the databases.
 type EditorWidget struct {
 	name           string
-	x0, y0, x1, y1 int
+	x0, y0, x1, y1 float32
 	label          string
 }
 
 // NewEditorWidget returns a pointer to a EditorWidget instance.
-func NewEditorWidget(name string, x0, y0, x1, y1 int, label string) *EditorWidget {
+func NewEditorWidget(name string, x0, y0, x1, y1 float32, label string) *EditorWidget {
 	return &EditorWidget{name: name, x0: x0, y0: y0, x1: x1, y1: y1, label: label}
 }
 
 // Layout implements the gocui.Manager interface.
 func (w *EditorWidget) Layout(g *gocui.Gui) error {
-	if v, err := g.SetView(w.name, w.x0, w.y0, w.x1, w.y1); err != nil {
+	maxX, maxY := g.Size()
+
+	x0 := int(w.x0 * float32(maxX))
+	y0 := int(w.y0 * float32(maxY))
+	x1 := int(w.x1 + float32(maxX))
+	y1 := int(w.y1 * float32(maxY))
+
+	if v, err := g.SetView(w.name, x0, y0, x1, y1); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
@@ -211,19 +251,26 @@ func (w *EditorWidget) Layout(g *gocui.Gui) error {
 // based off the context.
 type OutputWidget struct {
 	name           string
-	x0, y0, x1, y1 int
+	x0, y0, x1, y1 float32
 	label          string
 	initMsg        string
 }
 
 // NewOutputWidget returns a pointer to a OutputWidget instance.
-func NewOutputWidget(name string, x0, y0, x1, y1 int, label string, initMsg string) *OutputWidget {
+func NewOutputWidget(name string, x0, y0, x1, y1 float32, label string, initMsg string) *OutputWidget {
 	return &OutputWidget{name: name, x0: x0, y0: y0, x1: x1, y1: y1, label: label, initMsg: initMsg}
 }
 
 // Layout implements the gocui.Manager interface.
 func (w *OutputWidget) Layout(g *gocui.Gui) error {
-	if v, err := g.SetView(w.name, w.x0, w.y0, w.x1, w.y1); err != nil {
+	maxX, maxY := g.Size()
+
+	x0 := int(w.x0 * float32(maxX))
+	y0 := int(w.y0 * float32(maxY))
+	x1 := int(w.x1 + float32(maxX))
+	y1 := int(w.y1 * float32(maxY))
+
+	if v, err := g.SetView(w.name, x0, y0, x1, y1); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}

--- a/pkg/gui/widgets.go
+++ b/pkg/gui/widgets.go
@@ -10,28 +10,36 @@ import (
 )
 
 // ButtonWidget struct used to build buttons.
-// x and y work as factor to determine the widget size, since the terminal's size is retrieved in the Layout method.
+// y work as factor to determine the widget's height,
+// since the terminal's size is retrieved in the Layout method.
 type ButtonWidget struct {
 	name  string
-	x, y  float32
+	x     int
+	y     float32
 	w     int
 	color gocui.Attribute
 	label string
 }
 
 // NewButtonWidget returns a pointer to a ButtonWidget instance.
-func NewButtonWidget(name string, x, y float32, label string, color gocui.Attribute) *ButtonWidget {
-	return &ButtonWidget{name: name, x: x, y: y, w: len(label) + 1, label: label, color: color}
+func NewButtonWidget(name string, x int, y float32, label string, color gocui.Attribute) *ButtonWidget {
+	return &ButtonWidget{
+		name:  name,
+		x:     x,
+		y:     y,
+		w:     len(label) + 1,
+		label: label,
+		color: color,
+	}
 }
 
 // Layout implements the gocui.Manager interface.
 func (w *ButtonWidget) Layout(g *gocui.Gui) error {
 	_, maxY := g.Size()
 
-	x := int(w.x)
 	y := int(w.y * float32(maxY))
 
-	v, err := g.SetView(w.name, x, y, x+w.w, y+2)
+	v, err := g.SetView(w.name, w.x, y, w.x+w.w, y+2)
 	if err != nil {
 		if err != gocui.ErrUnknownView {
 			return err
@@ -46,7 +54,8 @@ func (w *ButtonWidget) Layout(g *gocui.Gui) error {
 }
 
 // LabelWidget struct used to display data to dynamic data to the user.
-// x and y work as factor to determine the widget size. Since the terminal's size is retrieved in the Layout method, using a fixed coordinates is not needed.
+// y work as factor to determine the widget's height,
+// since the terminal's size is retrieved in the Layout method.
 type LabelWidget struct {
 	name  string
 	x     int
@@ -65,10 +74,9 @@ func NewLabelWidget(name string, x int, y float32, label string, color gocui.Att
 func (w *LabelWidget) Layout(g *gocui.Gui) error {
 	_, maxY := g.Size()
 
-	x := w.x
 	y := int(w.y * float32(maxY))
 
-	v, err := g.SetView(w.name, x, y, x+w.w, y+2)
+	v, err := g.SetView(w.name, w.x, y, w.x+w.w, y+2)
 	if err != nil {
 		if err != gocui.ErrUnknownView {
 			return err
@@ -93,7 +101,15 @@ type BannerWidget struct {
 
 // NewBannerWidget returns a pointer to a BannerWidget instance.
 func NewBannerWidget(name string, x0, y0, x1, y1 float32, label string, color gocui.Attribute) *BannerWidget {
-	return &BannerWidget{name: name, x0: x0, y0: y0, x1: x1, y1: y1, label: label, color: color}
+	return &BannerWidget{
+		name:  name,
+		x0:    x0,
+		y0:    y0,
+		x1:    x1,
+		y1:    y1,
+		label: label,
+		color: color,
+	}
 }
 
 // Layout implements the gocui.Manager interface.
@@ -180,7 +196,15 @@ type NavigationWidget struct {
 
 // NewNavigationWidget returns a pointer to a NavigationWidget instance.
 func NewNavigationWidget(name string, x0, y0, x1, y1 float32, label string, options []string) *NavigationWidget {
-	return &NavigationWidget{name: name, x0: x0, y0: y0, x1: x1, y1: y1, label: label, options: options}
+	return &NavigationWidget{
+		name:    name,
+		x0:      x0,
+		y0:      y0,
+		x1:      x1,
+		y1:      y1,
+		label:   label,
+		options: options,
+	}
 }
 
 // Layout implements the gocui.Manager interface.
@@ -218,7 +242,14 @@ type EditorWidget struct {
 
 // NewEditorWidget returns a pointer to a EditorWidget instance.
 func NewEditorWidget(name string, x0, y0, x1, y1 float32, label string) *EditorWidget {
-	return &EditorWidget{name: name, x0: x0, y0: y0, x1: x1, y1: y1, label: label}
+	return &EditorWidget{
+		name:  name,
+		x0:    x0,
+		y0:    y0,
+		x1:    x1,
+		y1:    y1,
+		label: label,
+	}
 }
 
 // Layout implements the gocui.Manager interface.


### PR DESCRIPTION
## Description

There is an unexpected behavior that has been annoying me and other users lately and which is that UI doesn't redraw on terminal resize. This is due to a refactor that I did a few months ago. I defined some objects to encapsulate the most common widgets' behavior in the app, but I left the initial terminal's size fixed as initial parameter.
 
Fixes #123

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

By resizing my terminal size multiple times, until I get the desired outcome.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
