### PR TITLE
Increase the golangci-lint execution timeout

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,4 +46,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.46
-          args: --enable=golint --enable=godot
+          args: --enable=golint --enable=godot --timeout=3m


### PR DESCRIPTION
## Description

The golangci-lint workflow always ends up errorring it out like this:
`level=error msg="Timeout exceeded: try increasing it by passing --timeout option"`.
So I increased the timeout.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
