### PR TITLE
Fix terminal resize crash

### DIFF
--- a/pkg/gui/widgets.go
+++ b/pkg/gui/widgets.go
@@ -121,6 +121,14 @@ func (w *BannerWidget) Layout(g *gocui.Gui) error {
 	x1 := int(w.x1 * float32(maxX))
 	y1 := int(w.y1 * float32(maxY))
 
+	if x0 >= x1 {
+		x1 = x0 + 1
+	}
+
+	if y0 >= y1 {
+		y1 = y0 + 1
+	}
+
 	if v, err := g.SetView(w.name, x0, y0, x1, y1); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
@@ -167,6 +175,14 @@ func (w *TableWidget) Layout(g *gocui.Gui) error {
 	y0 := int(w.y0 * float32(maxY))
 	x1 := int(w.x1 * float32(maxX))
 	y1 := int(w.y1 * float32(maxY))
+
+	if x0 >= x1 {
+		x1 = x0 + 1
+	}
+
+	if y0 >= y1 {
+		y1 = y0 + 1
+	}
 
 	if v, err := g.SetView(w.name, x0, y0, x1, y1); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
@@ -216,6 +232,14 @@ func (w *NavigationWidget) Layout(g *gocui.Gui) error {
 	x1 := int(w.x1 + float32(maxX))
 	y1 := int(w.y1 * float32(maxY))
 
+	if x0 >= x1 {
+		x1 = x0 + 1
+	}
+
+	if y0 >= y1 {
+		y1 = y0 + 1
+	}
+
 	if v, err := g.SetView(w.name, x0, y0, x1, y1); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
@@ -261,6 +285,14 @@ func (w *EditorWidget) Layout(g *gocui.Gui) error {
 	x1 := int(w.x1 + float32(maxX))
 	y1 := int(w.y1 * float32(maxY))
 
+	if x0 >= x1 {
+		x1 = x0 + 1
+	}
+
+	if y0 >= y1 {
+		y1 = y0 + 1
+	}
+
 	if v, err := g.SetView(w.name, x0, y0, x1, y1); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
@@ -301,6 +333,14 @@ func (w *OutputWidget) Layout(g *gocui.Gui) error {
 	y0 := int(w.y0 * float32(maxY))
 	x1 := int(w.x1 + float32(maxX))
 	y1 := int(w.y1 * float32(maxY))
+
+	if x0 >= x1 {
+		x1 = x0 + 1
+	}
+
+	if y0 >= y1 {
+		y1 = y0 + 1
+	}
 
 	if v, err := g.SetView(w.name, x0, y0, x1, y1); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {

--- a/pkg/gui/widgets.go
+++ b/pkg/gui/widgets.go
@@ -116,19 +116,14 @@ func NewBannerWidget(name string, x0, y0, x1, y1 float32, label string, color go
 func (w *BannerWidget) Layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 
-	x0 := int(w.x0 * float32(maxX))
-	y0 := int(w.y0 * float32(maxY))
-	x1 := int(w.x1 * float32(maxX))
-	y1 := int(w.y1 * float32(maxY))
-
-	if x0 >= x1 {
-		x1 = x0 + 1
-	}
-
-	if y0 >= y1 {
-		y1 = y0 + 1
-	}
-
+	x0, y0, x1, y1 := handleWidgetSize(
+		maxX,
+		maxY,
+		int(w.x0*float32(maxX)),
+		int(w.y0*float32(maxY)),
+		int(w.x1*float32(maxX)),
+		int(w.y1*float32(maxY)),
+	)
 	if v, err := g.SetView(w.name, x0, y0, x1, y1); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
@@ -171,19 +166,14 @@ func NewTableWidget(name string, x0, y0, x1, y1 float32, label string, bgcolor, 
 func (w *TableWidget) Layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 
-	x0 := int(w.x0 * float32(maxX))
-	y0 := int(w.y0 * float32(maxY))
-	x1 := int(w.x1 * float32(maxX))
-	y1 := int(w.y1 * float32(maxY))
-
-	if x0 >= x1 {
-		x1 = x0 + 1
-	}
-
-	if y0 >= y1 {
-		y1 = y0 + 1
-	}
-
+	x0, y0, x1, y1 := handleWidgetSize(
+		maxX,
+		maxY,
+		int(w.x0*float32(maxX)),
+		int(w.y0*float32(maxY)),
+		int(w.x1*float32(maxX)),
+		int(w.y1*float32(maxY)),
+	)
 	if v, err := g.SetView(w.name, x0, y0, x1, y1); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
@@ -227,19 +217,14 @@ func NewNavigationWidget(name string, x0, y0, x1, y1 float32, label string, opti
 func (w *NavigationWidget) Layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 
-	x0 := int(w.x0 * float32(maxX))
-	y0 := int(w.y0 * float32(maxY))
-	x1 := int(w.x1 + float32(maxX))
-	y1 := int(w.y1 * float32(maxY))
-
-	if x0 >= x1 {
-		x1 = x0 + 1
-	}
-
-	if y0 >= y1 {
-		y1 = y0 + 1
-	}
-
+	x0, y0, x1, y1 := handleWidgetSize(
+		maxX,
+		maxY,
+		int(w.x0*float32(maxX)),
+		int(w.y0*float32(maxY)),
+		int(w.x1+float32(maxX)),
+		int(w.y1*float32(maxY)),
+	)
 	if v, err := g.SetView(w.name, x0, y0, x1, y1); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
@@ -280,19 +265,14 @@ func NewEditorWidget(name string, x0, y0, x1, y1 float32, label string) *EditorW
 func (w *EditorWidget) Layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 
-	x0 := int(w.x0 * float32(maxX))
-	y0 := int(w.y0 * float32(maxY))
-	x1 := int(w.x1 + float32(maxX))
-	y1 := int(w.y1 * float32(maxY))
-
-	if x0 >= x1 {
-		x1 = x0 + 1
-	}
-
-	if y0 >= y1 {
-		y1 = y0 + 1
-	}
-
+	x0, y0, x1, y1 := handleWidgetSize(
+		maxX,
+		maxY,
+		int(w.x0*float32(maxX)),
+		int(w.y0*float32(maxY)),
+		int(w.x1+float32(maxX)),
+		int(w.y1*float32(maxY)),
+	)
 	if v, err := g.SetView(w.name, x0, y0, x1, y1); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
@@ -329,19 +309,14 @@ func NewOutputWidget(name string, x0, y0, x1, y1 float32, label string, initMsg 
 func (w *OutputWidget) Layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 
-	x0 := int(w.x0 * float32(maxX))
-	y0 := int(w.y0 * float32(maxY))
-	x1 := int(w.x1 + float32(maxX))
-	y1 := int(w.y1 * float32(maxY))
-
-	if x0 >= x1 {
-		x1 = x0 + 1
-	}
-
-	if y0 >= y1 {
-		y1 = y0 + 1
-	}
-
+	x0, y0, x1, y1 := handleWidgetSize(
+		maxX,
+		maxY,
+		int(w.x0*float32(maxX)),
+		int(w.y0*float32(maxY)),
+		int(w.x1+float32(maxX)),
+		int(w.y1*float32(maxY)),
+	)
 	if v, err := g.SetView(w.name, x0, y0, x1, y1); err != nil {
 		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
@@ -353,4 +328,16 @@ func (w *OutputWidget) Layout(g *gocui.Gui) error {
 	}
 
 	return nil
+}
+
+func handleWidgetSize(maxX, maxY int, x0, y0, x1, y1 int) (int, int, int, int) {
+	if x0 >= x1 {
+		x1 = x0 + 1
+	}
+
+	if y0 >= y1 {
+		y1 = y0 + 1
+	}
+
+	return x0, y0, x1, y1
 }


### PR DESCRIPTION
## Description

The app crashes when the terminal reach its minimum size, this fixes that by preventing it to meet this condition:
![Screenshot from 2022-10-13 14-35-38](https://user-images.githubusercontent.com/12239167/195693177-2aa84165-fe5e-42eb-b0ad-930c8a5465e5.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested this out by resizing the terminal to its minimum size and the client didn't crash.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
