### PR TITLE
Multi config support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,17 +12,18 @@ import (
 
 // Define all the global flags.
 var (
-	cfg    bool
-	driver string
-	url    string
-	host   string
-	port   string
-	user   string
-	pass   string
-	schema string
-	db     string
-	ssl    string
-	limit  int
+	cfg     bool
+	cfgName string
+	driver  string
+	url     string
+	host    string
+	port    string
+	user    string
+	pass    string
+	schema  string
+	db      string
+	ssl     string
+	limit   int
 )
 
 // NewRootCmd returns the root command.
@@ -36,7 +37,7 @@ func NewRootCmd() *cobra.Command {
 			var err error
 
 			if cfg {
-				opts, err = config.Init()
+				opts, err = config.Init(cfgName)
 				if err != nil {
 					return err
 				}
@@ -99,7 +100,12 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
+	// config file flag.
 	rootCmd.PersistentFlags().BoolVarP(&cfg, "config", "", false, "get the connection data from a config file (default is $HOME/.dblab.yaml or the current directory)")
+	// cfg-name is used to indicate the name of the config section to be used to establish a
+	// connection with desired database.
+	// default: if empty, the first item of the databases options is gonna be selected.
+	rootCmd.Flags().StringVarP(&cfgName, "cfg-name", "", "", "Database config name section")
 
 	// global flags used to open a database connection.
 	rootCmd.Flags().StringVarP(&driver, "driver", "", "", "Database driver")

--- a/pkg/config/.dblab.yaml
+++ b/pkg/config/.dblab.yaml
@@ -1,9 +1,19 @@
 database:
-  host: "localhost"
-  port: 5432
-  db: "users"
-  password: "password"
-  user: "postgres"
-  schema: "public"
-  driver: "postgres"
+  - name: "test"
+    host: "localhost"
+    port: 5432
+    db: "users"
+    password: "password"
+    user: "postgres"
+    schema: "public"
+    driver: "postgres"
+  - name: "prod"
+    # example endpoint
+    host: "mydb.123456789012.us-east-1.rds.amazonaws.com"
+    port: 5432
+    db: "users"
+    password: "password"
+    user: "postgres"
+    schema: "public"
+    driver: "postgres"
 limit: 50

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,23 +22,26 @@ import (
 
 // Config struct is used to store the db connection data.
 type Config struct {
-	Database struct {
-		Host     string
-		Port     string
-		DB       string `validate:"required"`
-		User     string
-		Password string
-		Driver   string `validate:"required"`
-		Schema   string
-		SSL      string `default:"disable"`
-	}
-	User   string
-	Pswd   string
-	Host   string
-	Port   string
-	DBName string
-	Driver string
-	Limit  int `fig:"limit" default:"100"`
+	Database []Database
+	User     string
+	Pswd     string
+	Host     string
+	Port     string
+	DBName   string
+	Driver   string
+	Limit    int `fig:"limit" default:"100"`
+}
+
+type Database struct {
+	Name     string
+	Host     string
+	Port     string
+	DB       string `validate:"required"`
+	User     string
+	Password string
+	Driver   string `validate:"required"`
+	Schema   string
+	SSL      string `default:"disable"`
 }
 
 // New returns a config instance the with db connection data inplace based on the flags of a cobra command.
@@ -56,9 +59,10 @@ func New(cmd *cobra.Command) *Config {
 }
 
 // Init reads in config file and returns a commands/Options instance.
-func Init() (command.Options, error) {
+func Init(configName string) (command.Options, error) {
 	var opts command.Options
 	var cfg Config
+	var db Database
 
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -69,15 +73,25 @@ func Init() (command.Options, error) {
 		return opts, err
 	}
 
+	if configName != "" {
+		for _, d := range cfg.Database {
+			if configName == d.Name {
+				db = d
+			}
+		}
+	} else {
+		db = cfg.Database[0]
+	}
+
 	opts = command.Options{
-		Driver: cfg.Database.Driver,
-		Host:   cfg.Database.Host,
-		Port:   cfg.Database.Port,
-		User:   cfg.Database.User,
-		Pass:   cfg.Database.Password,
-		DBName: cfg.Database.DB,
-		SSL:    cfg.Database.SSL,
-		Schema: cfg.Database.Schema,
+		Driver: db.Driver,
+		Host:   db.Host,
+		Port:   db.Port,
+		User:   db.User,
+		Pass:   db.Password,
+		DBName: db.DB,
+		SSL:    db.SSL,
+		Schema: db.Schema,
 		Limit:  cfg.Limit,
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,15 +8,78 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	opts, err := config.Init()
+	type want struct {
+		host   string
+		port   string
+		dbname string
+		user   string
+		pass   string
+		driver string
+		schema string
+		limit  int
+	}
+	var tests = []struct {
+		name  string
+		input string
+		want  want
+	}{
+		{
+			name:  "empty config name",
+			input: "",
+			want: want{
+				host:   "localhost",
+				port:   "5432",
+				dbname: "users",
+				user:   "postgres",
+				pass:   "password",
+				driver: "postgres",
+				schema: "public",
+				limit:  50,
+			},
+		},
+		{
+			name:  "test config",
+			input: "test",
+			want: want{
+				host:   "localhost",
+				port:   "5432",
+				dbname: "users",
+				user:   "postgres",
+				pass:   "password",
+				driver: "postgres",
+				schema: "public",
+				limit:  50,
+			},
+		},
+		{
+			name:  "production config",
+			input: "prod",
+			want: want{
+				host:   "mydb.123456789012.us-east-1.rds.amazonaws.com",
+				port:   "5432",
+				dbname: "users",
+				user:   "postgres",
+				pass:   "password",
+				driver: "postgres",
+				schema: "public",
+				limit:  50,
+			},
+		},
+	}
 
-	assert.NoError(t, err)
-	assert.Equal(t, "localhost", opts.Host)
-	assert.Equal(t, "5432", opts.Port)
-	assert.Equal(t, "users", opts.DBName)
-	assert.Equal(t, "postgres", opts.User)
-	assert.Equal(t, "password", opts.Pass)
-	assert.Equal(t, "postgres", opts.Driver)
-	assert.Equal(t, "public", opts.Schema)
-	assert.Equal(t, 50, opts.Limit)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, err := config.Init(tt.input)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want.host, opts.Host)
+			assert.Equal(t, tt.want.port, opts.Port)
+			assert.Equal(t, tt.want.dbname, opts.DBName)
+			assert.Equal(t, tt.want.user, opts.User)
+			assert.Equal(t, tt.want.pass, opts.Pass)
+			assert.Equal(t, tt.want.driver, opts.Driver)
+			assert.Equal(t, tt.want.schema, opts.Schema)
+			assert.Equal(t, tt.want.limit, opts.Limit)
+		})
+	}
 }


### PR DESCRIPTION
# Pull Request Template

## Description

A user requested a very interesting feature on #137. Said feature is about to having multiple database configs, in order to have different database connection available defined in the `.dblab.yaml` file.

Example:

```yaml
database:
  - name: "test"
    host: "localhost"
    port: 5432
    db: "users"
    password: "password"
    user: "postgres"
    schema: "public"
    driver: "postgres"
  - name: "prod"
    # example endpoint
    host: "mydb.123456789012.us-east-1.rds.amazonaws.com"
    port: 5432
    db: "users"
    password: "password"
    user: "postgres"
    schema: "public"
    driver: "postgres"
limit: 50
```
I agreed on the usefulness of this feature since I wanted to implemented before.
Such a change could result in a non backward compatible feature, since some users would leave the `.dblab.yaml` file untouched after the next update. We can permit us such proceeding since we're still under 0.X.X version though, the API is not stable yet.

Fixes #137 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Tested it under quite a few different config files versions and scenarios.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
