### PR TITLE
Fix paginator

### DIFF
--- a/pkg/pagination/pagination.go
+++ b/pkg/pagination/pagination.go
@@ -1,6 +1,9 @@
 package pagination
 
-import "fmt"
+import (
+	"fmt"
+	"math"
+)
 
 // Manager handles the pagination.
 type Manager struct {
@@ -94,7 +97,7 @@ func (m *Manager) setTotalPages(count int) error {
 		return fmt.Errorf("limit should be greater than 0")
 	}
 
-	m.totalPages = count / m.limit
+	m.totalPages = int(math.Ceil(float64(count) / float64(m.limit)))
 
 	return nil
 }


### PR DESCRIPTION
## Description

I found out that `pagination` was acting up if the result set only has one page, the `total pages` value is always zero.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Refactor the test suite on the `pagination` package to make sure the bug got fixed

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
