### PR TITLE
Fix the installations script to remove the need to sudoon script executions

### DIFF
--- a/scripts/install_update_linux.sh
+++ b/scripts/install_update_linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # allow specifying different destination directory
-DIR="${DIR:-"/usr/local/bin"}"
+DIR="${DIR:-"$HOME/.local/bin"}"
 
 # get the OS
 OS=$(uname -s)
@@ -30,6 +30,6 @@ echo $GITHUB_URL
 
 # install/update the local binary
 curl -L -o dblab.tar.gz $GITHUB_URL
-tar xzvf dblab.tar.gz
-sudo mv -f dblab "$DIR"
+tar xzvf dblab.tar.gz dblab
+mv -f dblab "$DIR"
 rm dblab.tar.gz

--- a/scripts/install_update_sqlite_linux.sh
+++ b/scripts/install_update_sqlite_linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # allow specifying different destination directory
-DIR="${DIR:-"/usr/local/bin"}"
+DIR="${DIR:-"$HOME/.local/bin"}"
 
 # get the OS
 OS=$(uname -s)
@@ -30,6 +30,6 @@ echo $GITHUB_URL
 
 # install/update the local binary
 curl -L -o dblab.tar.gz $GITHUB_URL
-tar xzvf dblab.tar.gz
-sudo mv -f dblab-sqlite "$DIR"
+tar xzvf dblab.tar.gz dblab-sqlite
+mv -f dblab-sqlite "$DIR"
 rm dblab.tar.gz


### PR DESCRIPTION
## Description

Installation scripts used to require sudo on execution, since the binary was supposed to be downloaded at `/usr/local/bin` that requires root privileges. That won't be the case anymore since the binary will be stored at `$HOME/.local/bin`. 

Bonus: the script only unzips the binary instead of the whole content of the compressed file.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

* deleted the current binaries located at `/usr/local/bin` 
* ran the modified the bash scripts
* ran `$ where dblab` and ``$where dblab-sqlite`

Output:
```
$ /home/myuser/.local/bin/dblab
$ /home/myuser/.local/bin/dblab-sqlite  
```
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
