### PR TITLE
Add docker compose v2 to the target commands on makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ unit-test:
 .PHONY: int-test
 ## int-test: Runs the integration tests
 int-test:
-	docker-compose run --entrypoint=make dblab test
+	docker compose run --entrypoint=make dblab test
 
 .PHONY: linter
 ## linter: Runs the golangci-lint command
@@ -54,7 +54,7 @@ run-mysql: build
 .PHONY: run-sqlite3
 ## run-sqlite3: Runs the application with a connection to sqlite3
 run-sqlite3: build-sqlite3
-	docker-compose run --rm dblab-sqlite3
+	docker compose run --rm dblab-sqlite3
 	./dblab --db db/dblab.db --driver sqlite3
 
 .PHONY: run-url
@@ -75,12 +75,12 @@ run-config: build
 .PHONY: up
 ## up: Runs all the containers listed in the docker-compose.yml file
 up:
-	docker-compose up --build -d
+	docker compose up --build -d
 
 .PHONY: down
 ## down: Shut down all the containers listed in the docker-compose.yml file
 down:
-	docker-compose down
+	docker compose down
 
 .PHONY: form
 ## form: Runs the application with no arguments


### PR DESCRIPTION
## Description

No need to use `docker-compose` anymore, since V2 has been launched while ago and it's written in `Go`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Locally on my system. It's just for local development. Make sure you have this plugin installed and properly set up.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
