### PR TITLE
Default the limit to 100 if the limit prompt is ignored in form mode

### DIFF
--- a/pkg/form/form.go
+++ b/pkg/form/form.go
@@ -13,6 +13,10 @@ import (
 	"github.com/muesli/termenv"
 )
 
+const (
+	DefaultLimit = 100
+)
+
 var (
 	focusedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
 	noStyle      = lipgloss.NewStyle()
@@ -118,6 +122,10 @@ func (m *Model) SSL() string {
 
 // Limit returns the limit input value from the user.
 func (m *Model) Limit() (uint, error) {
+	// if the user skipped the question, resort to default value
+	if m.limitInput.Value() == "" {
+		return DefaultLimit, nil
+	}
 	limit, err := strconv.Atoi(m.limitInput.Value())
 	if err != nil {
 		return uint(0), err

--- a/pkg/form/form.go
+++ b/pkg/form/form.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	DefaultLimit = 100
+	defaultLimit = 100
 )
 
 var (
@@ -124,7 +124,7 @@ func (m *Model) SSL() string {
 func (m *Model) Limit() (uint, error) {
 	// if the user skipped the question, resort to default value
 	if m.limitInput.Value() == "" {
-		return DefaultLimit, nil
+		return defaultLimit, nil
 	}
 	limit, err := strconv.Atoi(m.limitInput.Value())
 	if err != nil {


### PR DESCRIPTION
There's a bug if the user attempts to start `dblab` via the form prompts and ignores the `limit>` prompt, this will cause `strconv.Atoi` to error out due to empty string.

This PR introduces a check for empty string and returns a defaulted value of `100`