### PR TITLE
Add a static cname at the root of docs_dir

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+dblab.danvergara.com


### PR DESCRIPTION
# Add a static cname at the root of docs_dir

## Description

We need to add a `CNAME` file to the root of  `docs_dir`, otherwise the `CNAME` fiel on `gh-page` branch gets deleted when it gets merged with the `main` branch

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
