### PR TITLE
Add ssl flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,19 +12,23 @@ import (
 
 // Define all the global flags.
 var (
-	cfg     bool
-	cfgName string
-	driver  string
-	url     string
-	host    string
-	port    string
-	user    string
-	pass    string
-	schema  string
-	db      string
-	ssl     string
-	limit   uint
-	socket  string
+	cfg         bool
+	cfgName     string
+	driver      string
+	url         string
+	host        string
+	port        string
+	user        string
+	pass        string
+	schema      string
+	db          string
+	ssl         string
+	limit       uint
+	socket      string
+	sslcert     string
+	sslkey      string
+	sslpassword string
+	sslrootcert string
 )
 
 // NewRootCmd returns the root command.
@@ -44,17 +48,21 @@ func NewRootCmd() *cobra.Command {
 				}
 			} else {
 				opts = command.Options{
-					Driver: driver,
-					URL:    url,
-					Host:   host,
-					Port:   port,
-					User:   user,
-					Pass:   pass,
-					DBName: db,
-					Schema: schema,
-					SSL:    ssl,
-					Limit:  limit,
-					Socket: socket,
+					Driver:      driver,
+					URL:         url,
+					Host:        host,
+					Port:        port,
+					User:        user,
+					Pass:        pass,
+					DBName:      db,
+					Schema:      schema,
+					SSL:         ssl,
+					Limit:       limit,
+					Socket:      socket,
+					SSLCert:     sslcert,
+					SSLKey:      sslkey,
+					SSLPassword: sslpassword,
+					SSLRootcert: sslrootcert,
 				}
 
 				if form.IsEmpty(opts) {
@@ -121,4 +129,26 @@ func init() {
 	rootCmd.Flags().StringVarP(&ssl, "ssl", "", "", "SSL mode")
 	rootCmd.Flags().UintVarP(&limit, "limit", "", 100, "Size of the result set from the table content query (should be greater than zero, otherwise the app will error out)")
 	rootCmd.Flags().StringVarP(&socket, "socket", "", "", "Path to a Unix socket file")
+	rootCmd.Flags().StringVarP(
+		&sslcert,
+		"sslcert",
+		"",
+		"~/.postgresql/postgresql.crt",
+		"This parameter specifies the file name of the client SSL certificate, replacing the default ~/.postgresql/postgresql.crt",
+	)
+	rootCmd.Flags().StringVarP(
+		&sslkey,
+		"sslkey",
+		"",
+		"~/.postgresql/postgresql.key",
+		"This parameter specifies the location for the secret key used for the client certificate. It can either specify a file name that will be used instead of the default ~/.postgresql/postgresql.key, or it can specify a key obtained from an external “engine”",
+	)
+	rootCmd.Flags().StringVarP(&sslpassword, "sslpassword", "", "", "This parameter specifies the password for the secret key specified in sslkey")
+	rootCmd.Flags().StringVarP(
+		&sslrootcert,
+		"sslrootcert",
+		"",
+		"~/.postgresql/root.crt",
+		"This parameter specifies the name of a file containing SSL certificate authority (CA) certificate(s) The default is ~/.postgresql/root.crt",
+	)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -133,14 +133,14 @@ func init() {
 		&sslcert,
 		"sslcert",
 		"",
-		"~/.postgresql/postgresql.crt",
+		"",
 		"This parameter specifies the file name of the client SSL certificate, replacing the default ~/.postgresql/postgresql.crt",
 	)
 	rootCmd.Flags().StringVarP(
 		&sslkey,
 		"sslkey",
 		"",
-		"~/.postgresql/postgresql.key",
+		"",
 		"This parameter specifies the location for the secret key used for the client certificate. It can either specify a file name that will be used instead of the default ~/.postgresql/postgresql.key, or it can specify a key obtained from an external “engine”",
 	)
 	rootCmd.Flags().StringVarP(&sslpassword, "sslpassword", "", "", "This parameter specifies the password for the secret key specified in sslkey")
@@ -148,7 +148,7 @@ func init() {
 		&sslrootcert,
 		"sslrootcert",
 		"",
-		"~/.postgresql/root.crt",
+		"",
 		"This parameter specifies the name of a file containing SSL certificate authority (CA) certificate(s) The default is ~/.postgresql/root.crt",
 	)
 }

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -15,8 +15,8 @@ type Options struct {
 	Schema string
 	Limit  uint
 	Socket string
+	SSL    string
 	// SSL connection params.
-	SSL         string
 	SSLCert     string
 	SSLKey      string
 	SSLPassword string

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -11,11 +11,16 @@ type Options struct {
 	User   string
 	Pass   string
 	DBName string
-	SSL    string
 	// PostgreSQL only.
 	Schema string
 	Limit  uint
 	Socket string
+	// SSL connection params.
+	SSL         string
+	SSLCert     string
+	SSLKey      string
+	SSLPassword string
+	SSLRootcert string
 }
 
 // SetDefault returns a Options struct and fills the empty

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -87,6 +87,22 @@ func BuildConnectionFromOpts(opts command.Options) (string, command.Options, err
 			}
 		}
 
+		if opts.SSLCert != "" {
+			query.Add("sslcert", opts.SSLCert)
+		}
+
+		if opts.SSLKey != "" {
+			query.Add("sslkey", opts.SSLKey)
+		}
+
+		if opts.SSLPassword != "" {
+			query.Add("sslpassword", opts.SSLPassword)
+		}
+
+		if opts.SSLRootcert != "" {
+			query.Add("sslrootcert", opts.SSLRootcert)
+		}
+
 		connDB := url.URL{
 			Scheme:   opts.Driver,
 			Host:     fmt.Sprintf("%v:%v", opts.Host, opts.Port),

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -82,6 +82,19 @@ func TestBuildConnectionFromOptsFromURL(t *testing.T) {
 				err:      ErrInvalidURLFormat,
 			},
 		},
+		{
+			name: "valid postgres url with sslmode equals to require",
+			given: given{
+				opts: command.Options{
+					// keep url params in alphetic orden
+					// see: https://github.com/golang/go/issues/29985
+					URL: "postgres://user:password@localhost:5432/db?sslcert=client-cert.pem&sslkey=client-key.pem&sslmode=require&sslrootcert=server-ca.pem",
+				},
+			},
+			want: want{
+				uri: "postgres://user:password@localhost:5432/db?sslcert=client-cert.pem&sslkey=client-key.pem&sslmode=require&sslrootcert=server-ca.pem",
+			},
+		},
 		// mysql
 		{
 			name: "valid mysql localhost",
@@ -234,6 +247,27 @@ func TestBuildConnectionFromOptsUserData(t *testing.T) {
 			},
 			want: want{
 				uri: "postgres://user:password@127.0.0.1:5432/db?sslmode=disable",
+			},
+		},
+		{
+			name: "success  ssl mode - require",
+			given: given{
+				opts: command.Options{
+					Driver: drivers.Postgres,
+					User:   "user",
+					Pass:   "password",
+					// fake instance.
+					Host:        "db-postgresql-nyc1-12345-do-user-123456-0.b.db.ondigitalocean.com",
+					Port:        "5432",
+					DBName:      "db",
+					SSL:         "require",
+					SSLCert:     "client-cert.pem",
+					SSLKey:      "client-key.pem",
+					SSLRootcert: "server-ca.pem",
+				},
+			},
+			want: want{
+				uri: "postgres://user:password@db-postgresql-nyc1-12345-do-user-123456-0.b.db.ondigitalocean.com:5432/db?sslcert=client-cert.pem&sslkey=client-key.pem&sslmode=require&sslrootcert=server-ca.pem",
 			},
 		},
 		{
@@ -459,6 +493,28 @@ func TestFormatPostgresURL(t *testing.T) {
 			},
 			want: want{
 				uri: "postgresql://user:password@localhost:5432/db?sslmode=disable",
+			},
+		},
+		{
+			name: "valid postgres url ssl mode require all params",
+			given: given{
+				opts: command.Options{
+					URL: "postgres://user:password@localhost:5432/db?sslcert=client-cert.pem&sslkey=client-key.pem&sslmode=require&sslrootcert=server-ca.pem",
+				},
+			},
+			want: want{
+				uri: "postgres://user:password@localhost:5432/db?sslcert=client-cert.pem&sslkey=client-key.pem&sslmode=require&sslrootcert=server-ca.pem",
+			},
+		},
+		{
+			name: "valid postgres url ssl mode require missing params",
+			given: given{
+				opts: command.Options{
+					URL: "postgres://user:password@localhost:5432/db?sslcert=client-cert.pem&sslkey=client-key.pem&sslmode=require",
+				},
+			},
+			want: want{
+				uri: "postgres://user:password@localhost:5432/db?sslcert=client-cert.pem&sslkey=client-key.pem&sslmode=require",
 			},
 		},
 		{

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -88,11 +88,11 @@ func TestBuildConnectionFromOptsFromURL(t *testing.T) {
 				opts: command.Options{
 					// keep url params in alphetic orden
 					// see: https://github.com/golang/go/issues/29985
-					URL: "postgres://user:password@localhost:5432/db?sslcert=client-cert.pem&sslkey=client-key.pem&sslmode=require&sslrootcert=server-ca.pem",
+					URL: "postgres://user:password@localhost:5432/db?sslcert=client-cert.pem&sslkey=client-key.pem&sslmode=require&sslrootcert=server-ca.crt",
 				},
 			},
 			want: want{
-				uri: "postgres://user:password@localhost:5432/db?sslcert=client-cert.pem&sslkey=client-key.pem&sslmode=require&sslrootcert=server-ca.pem",
+				uri: "postgres://user:password@localhost:5432/db?sslcert=client-cert.pem&sslkey=client-key.pem&sslmode=require&sslrootcert=server-ca.crt",
 			},
 		},
 		// mysql
@@ -263,11 +263,30 @@ func TestBuildConnectionFromOptsUserData(t *testing.T) {
 					SSL:         "require",
 					SSLCert:     "client-cert.pem",
 					SSLKey:      "client-key.pem",
-					SSLRootcert: "server-ca.pem",
+					SSLRootcert: "server-ca.crt",
 				},
 			},
 			want: want{
-				uri: "postgres://user:password@db-postgresql-nyc1-12345-do-user-123456-0.b.db.ondigitalocean.com:5432/db?sslcert=client-cert.pem&sslkey=client-key.pem&sslmode=require&sslrootcert=server-ca.pem",
+				uri: "postgres://user:password@db-postgresql-nyc1-12345-do-user-123456-0.b.db.ondigitalocean.com:5432/db?sslcert=client-cert.pem&sslkey=client-key.pem&sslmode=require&sslrootcert=server-ca.crt",
+			},
+		},
+		{
+			name: "success  ssl mode - require",
+			given: given{
+				opts: command.Options{
+					Driver: drivers.Postgres,
+					User:   "user",
+					Pass:   "password",
+					// fake instance.
+					Host:        "db-postgresql-nyc1-12345-do-user-123456-0.b.db.ondigitalocean.com",
+					Port:        "5432",
+					DBName:      "db",
+					SSL:         "require",
+					SSLRootcert: "server-ca.crt",
+				},
+			},
+			want: want{
+				uri: "postgres://user:password@db-postgresql-nyc1-12345-do-user-123456-0.b.db.ondigitalocean.com:5432/db?sslmode=require&sslrootcert=server-ca.crt",
 			},
 		},
 		{

--- a/pkg/form/form.go
+++ b/pkg/form/form.go
@@ -240,5 +240,19 @@ func Run() (command.Options, error) {
 
 // IsEmpty checks if the given options objects is empty.
 func IsEmpty(opts command.Options) bool {
-	return cmp.Equal(opts, command.Options{}, cmpopts.IgnoreFields(command.Options{}, "SSL", "Limit"))
+	return cmp.Equal(
+		opts,
+		command.Options{},
+		cmpopts.IgnoreFields(
+			command.Options{},
+			"SSL",
+			"Limit",
+			"Socket",
+			"SSL",
+			"SSLCert",
+			"SSLKey",
+			"SSLPassword",
+			"SSLRootcert",
+		),
+	)
 }

--- a/pkg/form/view.go
+++ b/pkg/form/view.go
@@ -10,7 +10,7 @@ func driverView(m *Model) string {
 	// The header.
 	s := "Select the database driver:"
 	var choices string
-	// Iterate over the driver.
+	// Iterate over the drivers.
 	for i, driver := range m.drivers {
 		choices += fmt.Sprintf("%s\n", checkbox(driver, m.cursor == i))
 	}
@@ -57,24 +57,58 @@ func viewInputs(m *Model) []string {
 }
 
 func sslView(m *Model) string {
+	sslModes := make([]string, 0)
+
 	switch m.driver {
 	case drivers.Postgres:
-		m.modes = []string{"disable", "require", "verify-full"}
+		sslModes = m.postgreSQLSSLModes
 	case drivers.MySQL:
-		m.modes = []string{"true", "false", "skip-verify", "preferred"}
+		sslModes = m.mySQLSSLModes
 	case drivers.SQLite:
-		m.modes = []string{}
+		sslModes = m.sqliteSSLModes
 	default:
-		m.modes = []string{"disable", "require", "verify-full"}
+		sslModes = m.postgreSQLSSLModes
 	}
 
 	// The header.
 	s := "\nSelect the ssl mode (just press enter if you selected sqlite3):"
 	var choices string
 	// Iterate over the driver.
-	for i, mode := range m.modes {
+	for i, mode := range sslModes {
 		choices += fmt.Sprintf("%s\n", checkbox(mode, m.cursor == i))
 	}
 
 	return fmt.Sprintf("%s\n\n%s", s, choices)
+}
+
+func sslConnView(m *Model) string {
+	s := "Introduce the SSL connection params:\n\n"
+
+	inputs := sslConnViewInputs(m)
+
+	for i := 0; i < len(inputs); i++ {
+		s += inputs[i]
+		if i < len(inputs)-1 {
+			s += "\n"
+		}
+	}
+
+	s += "\n"
+
+	return s
+}
+
+func sslConnViewInputs(m *Model) []string {
+	var inputs []string
+
+	if m.driver == drivers.Postgres && (m.sslMode == "require" || m.sslMode == "verify-full" || m.sslMode == "verify-ca") {
+		inputs = []string{
+			m.sslCertInput.View(),
+			m.sslKeyInput.View(),
+			m.sslPasswordInput.View(),
+			m.sslRootcertInput.View(),
+		}
+	}
+
+	return inputs
 }

--- a/pkg/form/view.go
+++ b/pkg/form/view.go
@@ -57,7 +57,7 @@ func viewInputs(m *Model) []string {
 }
 
 func sslView(m *Model) string {
-	sslModes := make([]string, 0)
+	var sslModes []string
 
 	switch m.driver {
 	case drivers.Postgres:


### PR DESCRIPTION
# Add SSL connection flags/query params

## Description
When it comes to SSL connection, dblab assumes that you have the default files set in your system (e.g., ~/.postgresql/root.crt) and there's no way to customize this behavior right now.

Fixes #153 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Ran the new feature in my system, QA'ing the app by trying multiple scenarios 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
