### PR TITLE
Add support to read ssl connection params from the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ dblab --host  db-postgresql-nyc3-56456-do-user-foo-0.fake.db.ondigitalocean.com 
 Enter previous flags every time is tedious, so `dblab` provides a couple of flags to help with it: `--config` and `--cfg-name`.
 
 `dblab` is going to look for a file called `.dblab.yaml`. For now, the only two places where you can drop a config file are $HOME ($HOME/.dblab.yaml) and the current directory where you run the command line tool.
-If you want to use this feature, `--config` is mandatory and `--cfg-name` may be omitted. The config file can store one or multiple database connection sections under the `database` field. `database` is an array, previously was an object only able to store a single connection section at a time. We strongly encourgae you to adopt the new format as of `v0.18.0`. `--cfg-name` takes the name of the desired database section to connect with. It can be omitted and its default values will be the first item on the array.
+If you want to use this feature, `--config` is mandatory and `--cfg-name` may be omitted. The config file can store one or multiple database connection sections under the `database` field. `database` is an array, previously was an object only able to store a single connection section at a time. We strongly encourgae you to adopt the new format as of `v0.18.0`. `--cfg-name` takes the name of the desired database section to connect with. It can be omitted and its default values will be the first item on the array. As of `v0.21.0`, ssl connections options are supported in the config file.
 
 ```sh
 # default: test
@@ -186,6 +186,8 @@ database:
     user: "postgres"
     schema: "public"
     driver: "postgres"
+    ssl: "require"
+    sslrootcert: "~/.postgresql/root.crt."
 # should be greater than 0, otherwise the app will error out
 limit: 50
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -146,6 +146,8 @@ If you want to use this feature, `--config` is mandatory and `--cfg-name` may be
 
 We strongly encourgae you to adopt the new format as of `v0.18.0`. `--cfg-name` takes the name of the desired database section to connect with. It can be omitted and its default values will be the first item on the array.
 
+As of `v0.21.0`, ssl connections options are supported in the config file.
+
 ```{ .sh .copy } 
 dbladb --config
 ```
@@ -177,6 +179,8 @@ database:
     user: "postgres"
     schema: "public"
     driver: "postgres"
+    ssl: "require"
+    sslrootcert: "~/.postgresql/root.crt."
 # should be greater than 0, otherwise the app will error out
 limit: 50
 ```

--- a/pkg/config/.dblab.yaml
+++ b/pkg/config/.dblab.yaml
@@ -16,4 +16,6 @@ database:
     user: "postgres"
     schema: "public"
     driver: "postgres"
+    ssl: "require"
+    sslrootcert: "~/.postgresql/root.crt."
 limit: 50

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -3,20 +3,26 @@ package config_test
 import (
 	"testing"
 
-	"github.com/danvergara/dblab/pkg/config"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/danvergara/dblab/pkg/config"
 )
 
 func TestInit(t *testing.T) {
 	type want struct {
-		host   string
-		port   string
-		dbname string
-		user   string
-		pass   string
-		driver string
-		schema string
-		limit  uint
+		host        string
+		port        string
+		dbname      string
+		user        string
+		pass        string
+		driver      string
+		schema      string
+		limit       uint
+		ssl         string
+		sslcert     string
+		sslkey      string
+		sslpassword string
+		sslrootcert string
 	}
 	var tests = []struct {
 		name  string
@@ -34,6 +40,7 @@ func TestInit(t *testing.T) {
 				pass:   "password",
 				driver: "postgres",
 				schema: "public",
+				ssl:    "disable",
 				limit:  50,
 			},
 		},
@@ -48,6 +55,7 @@ func TestInit(t *testing.T) {
 				pass:   "password",
 				driver: "postgres",
 				schema: "public",
+				ssl:    "disable",
 				limit:  50,
 			},
 		},
@@ -55,14 +63,16 @@ func TestInit(t *testing.T) {
 			name:  "production config",
 			input: "prod",
 			want: want{
-				host:   "mydb.123456789012.us-east-1.rds.amazonaws.com",
-				port:   "5432",
-				dbname: "users",
-				user:   "postgres",
-				pass:   "password",
-				driver: "postgres",
-				schema: "public",
-				limit:  50,
+				host:        "mydb.123456789012.us-east-1.rds.amazonaws.com",
+				port:        "5432",
+				dbname:      "users",
+				user:        "postgres",
+				pass:        "password",
+				driver:      "postgres",
+				schema:      "public",
+				ssl:         "require",
+				sslrootcert: "~/.postgresql/root.crt.",
+				limit:       50,
 			},
 		},
 	}
@@ -80,6 +90,12 @@ func TestInit(t *testing.T) {
 			assert.Equal(t, tt.want.driver, opts.Driver)
 			assert.Equal(t, tt.want.schema, opts.Schema)
 			assert.Equal(t, tt.want.limit, opts.Limit)
+			assert.Equal(t, tt.want.ssl, opts.SSL)
+			assert.Equal(t, tt.want.sslcert, opts.SSLCert)
+			assert.Equal(t, tt.want.sslkey, opts.SSLKey)
+			assert.Equal(t, tt.want.sslpassword, opts.SSLPassword)
+			assert.Equal(t, tt.want.sslrootcert, opts.SSLRootcert)
+
 		})
 	}
 }


### PR DESCRIPTION
# Support to read ssl connection params from the config file 

## Description

I didn't add the ssl conection params support to config file feature, so I did in this PR.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

I ran the test suite.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
