### PR TITLE
Fix goreleaser check

### DIFF
--- a/.github/workflows/check-goreleaser.yml
+++ b/.github/workflows/check-goreleaser.yml
@@ -3,7 +3,7 @@ name: goreleaser-check
 on:
   push:
     paths:
-      - '.goreleaser*'
+      - '.goreleaser.yaml'
 
 jobs:
   goreleaser-check:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,7 +33,7 @@ brews:
   - name: dblab
 
     # GitHub/GitLab repository to push the formula to
-    tap:
+    repository:
       owner: danvergara
       name: homebrew-tools
 


### PR DESCRIPTION
# Fix goreleaser check action

## Description

No big deal, As of gorelease v1.19.0, [tap](https://goreleaser.com/deprecations/#brewstap) field go deprecated. It has to be replaced by `repository`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Dropping a new change into the file is enough to trigger an check event.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
