### PR TITLE
feat: enable vim inspired navigation to jump around views (0,$,G,g)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,10 @@ Key                                     | Description
 <kbd>l</kbd>                            | Horizontal scrolling on the panel. Views: rows, constraints, structure and indexes
 <kbd>Arrow Left</kbd>                   | Horizontal scrolling on the panel. Views: rows, constraints, structure and indexes
 <kbd>h</kbd>                            | Horizontal scrolling on the panel. Views: rows, constraints, structure and indexes
+<kbd>0</kbd>                            | Move cursor to the start of the current line. Views: rows, constraints, and structure
+<kbd>$</kbd>                            | Move cursor to the end of the current line. Views: rows, constraints, and structure
+<kbd>g</kbd>                            | Move cursor to the top of the panel's dataset. Views: rows, constraints, and structure
+<kbd>G</kbd>                            | Move cursor to the bottom of the panel's dataset. Views: rows, constraints, and structure
 <kbd>Ctrl+c</kbd>                       | Quit
 
 ## Contribute

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -151,6 +151,16 @@ func initialKeyBindings() []keyBinding {
 		}...)
 	}
 
+	// vim motion inspired keys navigation.
+	for _, viewName := range []string{"rows", "structure", "constraints"} {
+		bindings = append(bindings, []keyBinding{
+			{view: viewName, key: '0', mod: gocui.ModNone, handler: slamCursor("left")},
+			{view: viewName, key: '$', mod: gocui.ModNone, handler: slamCursor("right")},
+			{view: viewName, key: 'G', mod: gocui.ModNone, handler: slamCursor("down")},
+			{view: viewName, key: 'g', mod: gocui.ModNone, handler: slamCursor("up")},
+		}...)
+	}
+
 	// defines the navigation on the "tables" view.
 	bindings = append(bindings, []keyBinding{
 		{view: "tables", key: 'k', mod: gocui.ModNone, handler: moveCursorVertically("up")},


### PR DESCRIPTION
## Description

I've been using dblab for a while, and every time I open it to explore tables and results i get a little frustrated with scrolling, so for myself I implemented some new key binds:

 - `0`: move cursor and origin all the way to the left
 - `$`: move cursor and origin all the way to the right
 - `g`: move cursor and origin all the way to the top
 - `G`: move cursor and origin all the way to the bottom


## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested by navigating around views with no data yet, partial data, and overflowing data. Cursor stays within bounds


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

Let me know if this requires any further testing or the style guidelines don't match up.

---

Also let me know if it's not needed or desired, sort of a drive-by pull request because I needed the feature and thought others might as well.