### PR TITLE
feat: add support to look for the config file in $XDG_CONFIG_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,17 @@ dblab --host  db-postgresql-nyc3-56456-do-user-foo-0.fake.db.ondigitalocean.com 
 
 Enter previous flags every time is tedious, so `dblab` provides a couple of flags to help with it: `--config` and `--cfg-name`.
 
-`dblab` is going to look for a file called `.dblab.yaml`. For now, the only two places where you can drop a config file are $HOME ($HOME/.dblab.yaml) and the current directory where you run the command line tool.
-If you want to use this feature, `--config` is mandatory and `--cfg-name` may be omitted. The config file can store one or multiple database connection sections under the `database` field. `database` is an array, previously was an object only able to store a single connection section at a time. We strongly encourgae you to adopt the new format as of `v0.18.0`. `--cfg-name` takes the name of the desired database section to connect with. It can be omitted and its default values will be the first item on the array. As of `v0.21.0`, ssl connections options are supported in the config file.
+`dblab` is going to look for a file called `.dblab.yaml`. Currently, there are three places where you can drop a config file:
+
+- $XDG_CONFIG_HOME ($XDG_CONFIG_HOME/.dblab.yaml)
+- $HOME ($HOME/.dblab.yaml)
+- . (the current directory where you run the command line tool)
+
+If you want to use this feature, `--config` is mandatory and `--cfg-name` may be omitted. The config file can store one or multiple database connection sections under the `database` field. `database` is an array, previously was an object only able to store a single connection section at a time. 
+
+We strongly encourgae you to adopt the new format as of `v0.18.0`. `--cfg-name` takes the name of the desired database section to connect with. It can be omitted and its default values will be the first item on the array. 
+
+As of `v0.21.0`, ssl connections options are supported in the config file.
 
 ```sh
 # default: test

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,7 +111,7 @@ func init() {
 	// will be global for your application.
 
 	// config file flag.
-	rootCmd.PersistentFlags().BoolVarP(&cfg, "config", "", false, "get the connection data from a config file (default is $HOME/.dblab.yaml or the current directory)")
+	rootCmd.PersistentFlags().BoolVarP(&cfg, "config", "", false, "Get the connection data from a config file (default locations are: current directory, $HOME/.dblab.yaml or $XDG_CONFIG_HOME/.dblab.yaml)")
 	// cfg-name is used to indicate the name of the config section to be used to establish a
 	// connection with desired database.
 	// default: if empty, the first item of the databases options is gonna be selected.

--- a/docs/tutorials/config-file.md
+++ b/docs/tutorials/config-file.md
@@ -7,7 +7,7 @@ For this example we'll be using a PostgreSQL database so the driver to use would
 
 ### Single database
 
-In order to connect to a local database hosted in `0.0.0.0:5432` we can just copy and paste the following configuration to the file with name `.dblab.yaml` stored in the root of your current directory or under your $HOME path ($HOME/.dblab.yaml).
+In order to connect to a local database hosted in `0.0.0.0:5432` we can just copy and paste the following configuration to the file with name `.dblab.yaml` stored either in the root of your current directory, in your $HOME path ($HOME/.dblab.yaml) or in your $XDG_CONFIG_HOME path ($XDG_CONFIG_HOME/.dblab.yaml).
 
 ```{ .yaml .copy }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,3 +1,4 @@
+
 You can get started by using the connection flags or by using a configuration file with the connection params.
 
 ```sh
@@ -140,7 +141,11 @@ dblab --host  db-postgresql-nyc3-56456-do-user-foo-0.fake.db.ondigitalocean.com 
 Entering the parameters and flags every time you want to use it is tedious, 
 so `dblab` provides a couple of flags to help with it: `--config` and `--cfg-name`.
 
-`dblab` is going to look for a file called `.dblab.yaml`. For now, the only two places where you can drop a config file are $HOME ($HOME/.dblab.yaml) and the current directory where you run the command line tool.  
+`dblab` is going to look for a file called `.dblab.yaml`. Currently, there are three places where you can drop a config file:
+
+- $XDG_CONFIG_HOME ($XDG_CONFIG_HOME/.dblab.yaml)
+- $HOME ($HOME/.dblab.yaml)
+- . (the current directory where you run the command line tool)
 
 If you want to use this feature, `--config` is mandatory and `--cfg-name` may be omitted. The config file can store one or multiple database connection sections under the `database` field. `database` is an array, previously was an object only able to store a single connection section at a time. 
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,12 +69,17 @@ func Init(configName string) (command.Options, error) {
 	var cfg Config
 	var db Database
 
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return opts, err
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return opts, err
 	}
 
-	if err := fig.Load(&cfg, fig.File(".dblab.yaml"), fig.Dirs(".", home)); err != nil {
+	if err := fig.Load(&cfg, fig.File(".dblab.yaml"), fig.Dirs(".", home, configDir)); err != nil {
 		return opts, err
 	}
 


### PR DESCRIPTION
## Description

Added support to look for the config file in the $XDG_CONFIG_HOME path using the [os](https://pkg.go.dev/os#UserConfigDir) package.

I've also updated the documentation in the necessary files, I think.

Implements #194

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

The test suite ran successfully. 

I didn't add any unit test in the `config_test.go` file. I tested (on Ubuntu) putting the `.dblab.yaml` in my $XDG_CONFIG_HOME path though.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
