### PR TITLE
Add postgres conn unix sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ $ dblab --url "mysql://user:password@unix(/path/to/socket/mysql.sock)/dbname?cha
 $ dblab --socket /path/to/socket/mysql.sock --user user --db dbname --pass password --ssl disable --port 5432 --driver mysql --limit 50
 ```
 
+Postgres connection through Unix sockets:
+
+```sh
+$ dblab --url "postgres://user:password@/dbname?host=/path/to/socket"
+$ dblab --socket /path/to/socket --user user --db dbname --pass password --ssl disable --port 5432 --driver postgres --limit 50
+```
+
 Now, it is possible to ensure SSL connections with `PostgreSQL` databases. SSL related parameters has been added, such as `--sslcert`, `--sslkey`, `--sslpassword`, `--sslrootcert`. More information on how to use such connection flags can be found [here](https://www.postgresql.org/docs/current/libpq-connect.html).
 
 ```{ .sh .copy }


### PR DESCRIPTION
# Add postgres conn unix sockets

## Description

This MR introduces the connection to posgres through Unix sockets.

```sh
dblab --url "postgres://user:password@/dbname?host=/path/to/socket"
dblab --socket /path/to/socket --user user --db dbname --pass password --ssl disable --port 5432 --driver postgres --limit 50
```
Fixes #195 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Test the connection string parsing running and adding more tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
