### PR TITLE
Add oracle driver to support oracle databases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,11 @@ run: build
 run-mysql: build
 	./dblab --host localhost --user myuser --db mydb --pass 5@klkbN#ABC --ssl enable --port 3306 --driver mysql
 
+.PHONY: run-oracle
+## run-oracle: Runs the application making a connection to the Oreacle database
+run-oracle: build
+	./dblab --host localhost --user system --db FREEPDB1 --pass password --port 1521 --driver oracle --limit 50
+
 .PHONY: run-mysql-socket
 ## run-mysql-socket: Runs the application with a connection to mysql through a socket file. In this example the socke file is located in /var/lib/mysql/mysql.sock.
 run-mysql-socket: build

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ dblab ![integration tests](https://github.com/danvergara/dblab/actions/workflows
   <img style="float: right;" src="assets/gopher-dblab.png" alt="dblab logo"/  width=200>
 </p>
 
-__Interactive client for PostgreSQL, MySQL and SQLite3.__
+__Interactive client for PostgreSQL, MySQL, SQLite3 and Oracle.__
 
 <img src="screenshots/dblab-cover.png" />
 
@@ -37,7 +37,7 @@ dblab is a fast and lightweight interactive terminal based UI application for Po
 written in Go and works on OSX, Linux and Windows machines. Main idea behind using Go for backend development
 is to utilize ability of the compiler to produce zero-dependency binaries for
 multiple platforms. dblab was created as an attempt to build very simple and portable
-application to work with local or remote PostgreSQL/MySQL/SQLite3 databases.
+application to work with local or remote PostgreSQL/MySQL/SQLite3/Oracle databases.
 
 ## Features
 
@@ -91,20 +91,27 @@ Available Commands:
   version     The version of the project
 
 Flags:
-      --cfg-name string   Database config name section
-      --config          get the connection data from a config file (default is $HOME/.dblab.yaml or the current directory)
-      --db string       Database name
-      --driver string   Database driver
-  -h, --help            help for dblab
-      --host string     Server host name or IP
-      --limit int       Size of the result set from the table content query (should be greater than zero, otherwise the app will error out) (default 100)
-      --pass string     Password for user
-      --port string     Server port
-      --schema string   Database schema (postgres only)
-      --socket string     Path to a Unix socket file
-      --ssl string      SSL mode
-  -u, --url string      Database connection string
-      --user string     Database user
+      --cfg-name string      Database config name section
+      --config               Get the connection data from a config file (default locations are: current directory, $HOME/.dblab.yaml or $XDG_CONFIG_HOME/.dblab.yaml)
+      --db string            Database name
+      --driver string        Database driver
+  -h, --help                 help for dblab
+      --host string          Server host name or IP
+      --limit uint           Size of the result set from the table content query (should be greater than zero, otherwise the app will error out) (default 100)
+      --pass string          Password for user
+      --port string          Server port
+      --schema string        Database schema (postgres only)
+      --socket string        Path to a Unix socket file
+      --ssl string           SSL mode
+      --ssl-verify string    [enable|disable] or [true|false] enable ssl verify for the server
+      --sslcert string       This parameter specifies the file name of the client SSL certificate, replacing the default ~/.postgresql/postgresql.crt
+      --sslkey string        This parameter specifies the location for the secret key used for the client certificate. It can either specify a file name that will be used instead of the default ~/.postgresql/postgresql.key, or it can specify a key obtained from an external “engine”
+      --sslpassword string   This parameter specifies the password for the secret key specified in sslkey
+      --sslrootcert string   This parameter specifies the name of a file containing SSL certificate authority (CA) certificate(s) The default is ~/.postgresql/root.crt
+      --trace-file string    File name for trace log
+  -u, --url string           Database connection string
+      --user string          Database user
+      --wallet string        Path for auto-login oracle wallet
 
 Use "dblab [command] --help" for more information about a command.
 ```
@@ -118,6 +125,7 @@ You can start the app passing no flags or parameters, you'll be asked for connec
 ```sh
 $ dblab --host localhost --user myuser --db users --pass password --ssl disable --port 5432 --driver postgres --limit 50
 $ dblab --db path/to/file.sqlite3 --driver sqlite
+$ dblab --host localhost --user system --db FREEPDB1 --pass password --port 1521 --driver oracle --limit 50
 ```
 
 Connection URL scheme is also supported:
@@ -126,6 +134,7 @@ Connection URL scheme is also supported:
 $ dblab --url postgres://user:password@host:port/database?sslmode=[mode]
 $ dblab --url mysql://user:password@tcp(host:port)/db
 $ dblab --url file:test.db?cache=shared&mode=memory
+$ dblab --url oracle://user:password@localhost:1521/db
 ```
 
 if you're using PostgreSQL, you have the option to define the schema you want to work with, the default value is `public`.

--- a/README.md
+++ b/README.md
@@ -213,6 +213,16 @@ database:
     driver: "postgres"
     ssl: "require"
     sslrootcert: "~/.postgresql/root.crt."
+  - name: "oracle"
+    host: "localhost"
+    port: 1521
+    db: "FREEPDB1 "
+    password: "password"
+    user: "system"
+    driver: "oracle"
+    ssl: "enable"
+    wallet: "path/to/wallet"
+    ssl-verify: true
 # should be greater than 0, otherwise the app will error out
 limit: 50
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,13 +1,14 @@
 package cmd
 
 import (
+	"github.com/danvergara/gocui"
+	"github.com/spf13/cobra"
+
 	"github.com/danvergara/dblab/pkg/app"
 	"github.com/danvergara/dblab/pkg/command"
 	"github.com/danvergara/dblab/pkg/config"
 	"github.com/danvergara/dblab/pkg/connection"
 	"github.com/danvergara/dblab/pkg/form"
-	"github.com/danvergara/gocui"
-	"github.com/spf13/cobra"
 )
 
 // Define all the global flags.
@@ -29,6 +30,10 @@ var (
 	sslkey      string
 	sslpassword string
 	sslrootcert string
+	// oracle specific.
+	traceFile string
+	sslVerify string
+	wallet    string
 )
 
 // NewRootCmd returns the root command.
@@ -63,6 +68,9 @@ func NewRootCmd() *cobra.Command {
 					SSLKey:      sslkey,
 					SSLPassword: sslpassword,
 					SSLRootcert: sslrootcert,
+					SSLVerify:   sslVerify,
+					TraceFile:   traceFile,
+					Wallet:      wallet,
 				}
 
 				if form.IsEmpty(opts) {
@@ -111,7 +119,8 @@ func init() {
 	// will be global for your application.
 
 	// config file flag.
-	rootCmd.PersistentFlags().BoolVarP(&cfg, "config", "", false, "Get the connection data from a config file (default locations are: current directory, $HOME/.dblab.yaml or $XDG_CONFIG_HOME/.dblab.yaml)")
+	rootCmd.PersistentFlags().
+		BoolVarP(&cfg, "config", "", false, "Get the connection data from a config file (default locations are: current directory, $HOME/.dblab.yaml or $XDG_CONFIG_HOME/.dblab.yaml)")
 	// cfg-name is used to indicate the name of the config section to be used to establish a
 	// connection with desired database.
 	// default: if empty, the first item of the databases options is gonna be selected.
@@ -127,7 +136,8 @@ func init() {
 	rootCmd.Flags().StringVarP(&db, "db", "", "", "Database name")
 	rootCmd.Flags().StringVarP(&schema, "schema", "", "", "Database schema (postgres only)")
 	rootCmd.Flags().StringVarP(&ssl, "ssl", "", "", "SSL mode")
-	rootCmd.Flags().UintVarP(&limit, "limit", "", 100, "Size of the result set from the table content query (should be greater than zero, otherwise the app will error out)")
+	rootCmd.Flags().
+		UintVarP(&limit, "limit", "", 100, "Size of the result set from the table content query (should be greater than zero, otherwise the app will error out)")
 	rootCmd.Flags().StringVarP(&socket, "socket", "", "", "Path to a Unix socket file")
 	rootCmd.Flags().StringVarP(
 		&sslcert,
@@ -143,7 +153,8 @@ func init() {
 		"",
 		"This parameter specifies the location for the secret key used for the client certificate. It can either specify a file name that will be used instead of the default ~/.postgresql/postgresql.key, or it can specify a key obtained from an external “engine”",
 	)
-	rootCmd.Flags().StringVarP(&sslpassword, "sslpassword", "", "", "This parameter specifies the password for the secret key specified in sslkey")
+	rootCmd.Flags().
+		StringVarP(&sslpassword, "sslpassword", "", "", "This parameter specifies the password for the secret key specified in sslkey")
 	rootCmd.Flags().StringVarP(
 		&sslrootcert,
 		"sslrootcert",
@@ -151,4 +162,8 @@ func init() {
 		"",
 		"This parameter specifies the name of a file containing SSL certificate authority (CA) certificate(s) The default is ~/.postgresql/root.crt",
 	)
+	rootCmd.Flags().
+		StringVarP(&sslVerify, "ssl-verify", "", "", "[enable|disable] or [true|false] enable ssl verify for the server")
+	rootCmd.Flags().StringVarP(&traceFile, "trace-file", "", "", "File name for trace log")
+	rootCmd.Flags().StringVarP(&wallet, "wallet", "", "", "Path for auto-login oracle wallet")
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,15 @@ services:
     networks:
       - dblab
 
+  oracle:
+    image: container-registry.oracle.com/database/free:latest
+    environment:
+      ORACLE_PWD: password
+    ports:
+      - '1521:1521'
+    networks:
+      - dblab
+
   dblab:
     build:
       context: .

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/lib/pq v1.10.6
 	github.com/muesli/termenv v0.12.0
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/sijms/go-ora/v2 v2.8.19
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.7.2
 	golang.org/x/text v0.3.7

--- a/go.sum
+++ b/go.sum
@@ -1055,6 +1055,8 @@ github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9Nz
 github.com/shopspring/decimal v0.0.0-20200227202807-02e2044944cc/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/sijms/go-ora/v2 v2.8.19 h1:7LoKZatDYGi18mkpQTR/gQvG9yOdtc7hPAex96Bqisc=
+github.com/sijms/go-ora/v2 v2.8.19/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/pkg/client/oracle.go
+++ b/pkg/client/oracle.go
@@ -1,0 +1,65 @@
+package client
+
+import (
+	"fmt"
+
+	sq "github.com/Masterminds/squirrel"
+	_ "github.com/sijms/go-ora/v2"
+)
+
+// oracle struct is in charge of perform all the oracle related queries.
+type oracle struct{}
+
+// a validation to see if oracle is implementing databaseQuerier.
+var _ databaseQuerier = (*oracle)(nil)
+
+// returns a pointer to a oracle struct, it receives an schema as a parameter.
+func newOracle() *oracle {
+	o := oracle{}
+
+	return &o
+}
+
+// ShowTables returns a query to retrieve all the tables.
+func (p *oracle) ShowTables() (string, []interface{}, error) {
+	query := "SELECT table_name FROM user_tables"
+	return query, nil, nil
+}
+
+// TableStructure returns a query string to get all the relevant information of a given table.
+func (p *oracle) TableStructure(tableName string) (string, []interface{}, error) {
+	query := fmt.Sprintf("DESCRIBE %s;", tableName)
+	return query, nil, nil
+}
+
+// Constraints returns all the constraints of a given table.
+func (p *oracle) Constraints(tableName string) (string, []interface{}, error) {
+	query := sq.Select(
+		`tc.constraint_name`,
+		`tc.constraint_type`,
+	).
+		From("user_constraints AS tc").
+		Where(sq.Eq{"tc.table_name": tableName}).
+		PlaceholderFormat(sq.Colon)
+
+	sql, args, err := query.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+
+	return sql, args, err
+}
+
+// Indexes returns the indexes of a table.
+func (p *oracle) Indexes(tableName string) (string, []interface{}, error) {
+	sql, args, err := sq.Select("*").
+		From("all_indexes").
+		Where(sq.Eq{"table_name": tableName}).
+		PlaceholderFormat(sq.Colon).
+		ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+
+	return sql, args, err
+}

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -21,6 +21,10 @@ type Options struct {
 	SSLKey      string
 	SSLPassword string
 	SSLRootcert string
+	// oracle specific.
+	TraceFile string
+	SSLVerify string
+	Wallet    string
 }
 
 // SetDefault returns a Options struct and fills the empty

--- a/pkg/config/.dblab.yaml
+++ b/pkg/config/.dblab.yaml
@@ -18,4 +18,15 @@ database:
     driver: "postgres"
     ssl: "require"
     sslrootcert: "~/.postgresql/root.crt."
+  - name: "oracle"
+    host: "localhost"
+    port: 1521
+    db: "FREEPDB1 "
+    password: "password"
+    user: "system"
+    driver: "oracle"
+    ssl: "enable"
+    wallet: "path/to/wallet"
+    ssl-verify: true
+    trace: "trace.log"
 limit: 50

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,12 +41,19 @@ type Database struct {
 	Password string
 	Driver   string `validate:"required"`
 	Schema   string
+
 	// SSL connection params.
-	SSL         string `default:"disable"`
+	SSL string `default:"disable"`
+
 	SSLCert     string `fig:"sslcert"`
 	SSLKey      string `fig:"sslkey"`
 	SSLPassword string `fig:"sslpassword"`
 	SSLRootcert string `fig:"sslrootcert"`
+
+	// oracle specific.
+	TraceFile string `fig:"trace"`
+	SSLVerify string `fig:"ssl-verify"`
+	Wallet    string `fig:"wallet"`
 }
 
 // New returns a config instance the with db connection data inplace based on the flags of a cobra command.
@@ -58,7 +65,8 @@ func New(cmd *cobra.Command) *Config {
 	cmd.PersistentFlags().StringVarP(&conf.Port, "port", "", os.Getenv("DB_PORT"), "DB port")
 	cmd.PersistentFlags().StringVarP(&conf.Host, "host", "", os.Getenv("DB_HOST"), "DB host")
 	cmd.PersistentFlags().StringVarP(&conf.DBName, "name", "", os.Getenv("DB_NAME"), "DB name")
-	cmd.PersistentFlags().StringVarP(&conf.Driver, "driver", "", os.Getenv("DB_DRIVER"), "DB driver")
+	cmd.PersistentFlags().
+		StringVarP(&conf.Driver, "driver", "", os.Getenv("DB_DRIVER"), "DB driver")
 
 	return conf
 }
@@ -111,6 +119,9 @@ func Init(configName string) (command.Options, error) {
 		SSLKey:      db.SSLKey,
 		SSLPassword: db.SSLPassword,
 		SSLRootcert: db.SSLRootcert,
+		TraceFile:   db.TraceFile,
+		SSLVerify:   db.SSLVerify,
+		Wallet:      db.Wallet,
 	}
 
 	return opts, nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -23,6 +23,9 @@ func TestInit(t *testing.T) {
 		sslkey      string
 		sslpassword string
 		sslrootcert string
+		traceFile   string
+		sslVerify   string
+		wallet      string
 	}
 	var tests = []struct {
 		name  string
@@ -73,6 +76,23 @@ func TestInit(t *testing.T) {
 				ssl:         "require",
 				sslrootcert: "~/.postgresql/root.crt.",
 				limit:       50,
+			},
+		},
+		{
+			name:  "oracle",
+			input: "oracle",
+			want: want{
+				host:      "localhost",
+				port:      "1521",
+				dbname:    "FREEPDB1 ",
+				user:      "system",
+				pass:      "password",
+				driver:    "oracle",
+				ssl:       "enable",
+				sslVerify: "true",
+				wallet:    "path/to/wallet",
+				traceFile: "trace.log",
+				limit:     50,
 			},
 		},
 	}

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -30,6 +30,9 @@ var (
 	ErrInvalidMySQLURLFormat = errors.New(
 		"invalid url - valid format: mysql://user:password@tcp(host:port)/db",
 	)
+	ErrInvalidOracleURLFormat = errors.New(
+		"invalid url - valid format: oracle://user:pass@server/service_name",
+	)
 	// ErrInvalidURLFormat is used to notify the url is invalid.
 	ErrInvalidURLFormat = errors.New("invalid url")
 	// ErrInvalidDriver is used to notify that the provided driver is not supported.
@@ -77,7 +80,9 @@ func BuildConnectionFromOpts(opts command.Options) (string, command.Options, err
 		}
 
 		if strings.HasPrefix(opts.URL, "oracle:") {
-			return opts.URL, opts, nil
+			opts.Driver = drivers.Oracle
+			conn, err := formatOracleURL(opts)
+			return conn, opts, err
 		}
 
 		return "", opts, fmt.Errorf("%s: %w", opts.URL, ErrInvalidURLFormat)
@@ -97,13 +102,31 @@ func BuildConnectionFromOpts(opts command.Options) (string, command.Options, err
 			return "", opts, fmt.Errorf("%v : %w", err, ErrInvalidPostgresURLFormat)
 		}
 
+		urloptions := make(map[string]string)
+
+		if opts.SSL != "" {
+			urloptions["SSL"] = opts.SSL
+		}
+
+		if opts.SSLVerify != "" {
+			urloptions["SSL Verify"] = opts.SSLVerify
+		}
+
+		if opts.TraceFile != "" {
+			urloptions["TRACE FILE"] = opts.TraceFile
+		}
+
+		if opts.Wallet != "" {
+			urloptions["wallet"] = url.QueryEscape(opts.Wallet)
+		}
+
 		connStr := go_ora.BuildUrl(
 			opts.Host,
 			iPort,
 			opts.DBName,
 			opts.User,
 			opts.Pass,
-			nil,
+			urloptions,
 		)
 
 		return connStr, opts, nil
@@ -291,6 +314,31 @@ func formatMySQLURL(opts command.Options) (string, error) {
 	return uri.String(), nil
 }
 
+// formatOracleURL returns valid uri for oracle connection.
+func formatOracleURL(opts command.Options) (string, error) {
+	if !hasValidOraclePrefix(opts.URL) {
+		return "", fmt.Errorf("invalid prefix %s : %w", opts.URL, ErrInvalidOracleURLFormat)
+	}
+
+	uri, err := url.Parse(opts.URL)
+	if err != nil {
+		return "", fmt.Errorf("%v : %w", err, ErrInvalidOracleURLFormat)
+	}
+
+	result := map[string]string{}
+	for k, v := range uri.Query() {
+		result[strings.ToLower(k)] = v[0]
+	}
+
+	query := url.Values{}
+	for k, v := range result {
+		query.Add(k, v)
+	}
+	uri.RawQuery = query.Encode()
+
+	return uri.String(), nil
+}
+
 // validates if dsn pattern match with the parameter.
 func parseDSN(dsn string) (string, error) {
 	matches := dsnPattern.FindStringSubmatch(dsn)
@@ -314,6 +362,11 @@ func hasValidPostgresPrefix(rawurl string) bool {
 // hasValidMySQLPrefix checks if a given url has the driver name in it.
 func hasValidMySQLPrefix(rawurl string) bool {
 	return strings.HasPrefix(rawurl, "mysql://")
+}
+
+// hasValidOraclePrefix checks if a given url has the driver name in it.
+func hasValidOraclePrefix(rawurl string) bool {
+	return strings.HasPrefix(rawurl, "oracle://")
 }
 
 func hasValidSqlite3FileExtension(fileName string) bool {

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -38,6 +38,18 @@ func TestBuildConnectionFromOptsFromURL(t *testing.T) {
 		given given
 		want  want
 	}{
+		// oracle
+		{
+			name: "valid oracle url",
+			given: given{
+				opts: command.Options{
+					URL: "oracle://user:pass@server:1521/service_name",
+				},
+			},
+			want: want{
+				uri: "oracle://user:pass@server:1521/service_name",
+			},
+		},
 		// postgres
 		{
 			name: "valid socket connection with postgres with no password or user",
@@ -249,6 +261,40 @@ func TestBuildConnectionFromOptsUserData(t *testing.T) {
 		given given
 		want  want
 	}{
+		// oracle
+		{
+			name: "success - oracle",
+			given: given{
+				opts: command.Options{
+					Driver: drivers.Oracle,
+					User:   "user",
+					Pass:   "password",
+					Host:   "localhost",
+					Port:   "1521",
+					DBName: "db",
+				},
+			},
+			want: want{
+				uri: "oracle://user:password@localhost:1521/db?",
+			},
+		},
+		{
+			name: "success - ssl enable - oracle",
+			given: given{
+				opts: command.Options{
+					Driver: drivers.Oracle,
+					User:   "user",
+					Pass:   "password",
+					Host:   "localhost",
+					Port:   "1521",
+					DBName: "db",
+					SSL:    "enable",
+				},
+			},
+			want: want{
+				uri: "oracle://user:password@localhost:1521/db?SSL=enable",
+			},
+		},
 		// postgres
 		{
 			name: "success - postgres socket connection without password",

--- a/pkg/drivers/drivers.go
+++ b/pkg/drivers/drivers.go
@@ -5,4 +5,5 @@ const (
 	PostgreSQL string = "postgresql"
 	MySQL      string = "mysql"
 	SQLite     string = "sqlite"
+	Oracle     string = "oracle"
 )

--- a/pkg/form/form.go
+++ b/pkg/form/form.go
@@ -7,10 +7,11 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/danvergara/dblab/pkg/command"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/muesli/termenv"
+
+	"github.com/danvergara/dblab/pkg/command"
 )
 
 const (
@@ -39,6 +40,11 @@ type Model struct {
 	sslPasswordInput textinput.Model
 	sslRootcertInput textinput.Model
 
+	// oracle specific.
+	traceFileInput textinput.Model
+	sslVerifyInput textinput.Model
+	walletInput    textinput.Model
+
 	// std data.
 	hostInput     textinput.Model
 	portInput     textinput.Model
@@ -51,6 +57,7 @@ type Model struct {
 	// ssl.
 	postgreSQLSSLModes []string
 	mySQLSSLModes      []string
+	oracleSSLModes     []string
 	sqliteSSLModes     []string
 	sslMode            string
 }
@@ -148,6 +155,18 @@ func (m *Model) SSLRootcert() string {
 	return m.sslRootcertInput.Value()
 }
 
+func (m *Model) SSLVerify() string {
+	return m.sslVerifyInput.Value()
+}
+
+func (m *Model) TraceFile() string {
+	return m.traceFileInput.Value()
+}
+
+func (m *Model) Wallet() string {
+	return m.walletInput.Value()
+}
+
 // Limit returns the limit input value from the user.
 func (m *Model) Limit() (uint, error) {
 	// if the user skipped the question, resort to default value
@@ -235,15 +254,28 @@ func initModel() Model {
 	sslRootCert.Placeholder = "The name of a file containing SSL certificate authority (CA) certificate(s)"
 	sslRootCert.CharLimit = 1000
 
+	sslVerify := textinput.NewModel()
+	sslVerify.Placeholder = "SSL Verify"
+	sslVerify.CharLimit = 200
+
+	traceFile := textinput.NewModel()
+	traceFile.Placeholder = "Trace file"
+	traceFile.CharLimit = 1000
+
+	wallet := textinput.NewModel()
+	wallet.Placeholder = "Path to wallet"
+	wallet.CharLimit = 1000
+
 	m := Model{
 		// the supported drivers by the client.
-		drivers: []string{"postgres", "mysql", "sqlite"},
+		drivers: []string{"postgres", "mysql", "sqlite", "oracle"},
 		// our default value.
 		driver: "postgres",
 
 		sslMode:            "disable",
 		postgreSQLSSLModes: []string{"disable", "require", "verify-full", "verify-ca"},
 		mySQLSSLModes:      []string{"true", "false", "skip-verify", "preferred"},
+		oracleSSLModes:     []string{"enable", "disable"},
 		sqliteSSLModes:     []string{},
 
 		hostInput:        host,
@@ -257,6 +289,9 @@ func initModel() Model {
 		sslKeyInput:      sslKey,
 		sslPasswordInput: sslPassword,
 		sslRootcertInput: sslRootCert,
+		sslVerifyInput:   sslVerify,
+		traceFileInput:   traceFile,
+		walletInput:      wallet,
 	}
 
 	return m
@@ -286,6 +321,9 @@ func Run() (command.Options, error) {
 		SSLKey:      m.SSLKey(),
 		SSLPassword: m.SSLPassword(),
 		SSLRootcert: m.SSLRootcert(),
+		SSLVerify:   m.SSLVerify(),
+		TraceFile:   m.TraceFile(),
+		Wallet:      m.Wallet(),
 		Limit:       limit,
 	}
 
@@ -311,6 +349,9 @@ func IsEmpty(opts command.Options) bool {
 			"SSLKey",
 			"SSLPassword",
 			"SSLRootcert",
+			"TraceFile",
+			"SSLVerify",
+			"Wallet",
 		),
 	)
 }

--- a/pkg/form/form_test.go
+++ b/pkg/form/form_test.go
@@ -3,9 +3,10 @@ package form_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/danvergara/dblab/pkg/command"
 	"github.com/danvergara/dblab/pkg/form"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestIsEmpty(t *testing.T) {

--- a/pkg/form/view.go
+++ b/pkg/form/view.go
@@ -64,6 +64,8 @@ func sslView(m *Model) string {
 		sslModes = m.postgreSQLSSLModes
 	case drivers.MySQL:
 		sslModes = m.mySQLSSLModes
+	case drivers.Oracle:
+		sslModes = m.oracleSSLModes
 	case drivers.SQLite:
 		sslModes = m.sqliteSSLModes
 	default:
@@ -100,13 +102,21 @@ func sslConnView(m *Model) string {
 
 func sslConnViewInputs(m *Model) []string {
 	var inputs []string
-
-	if m.driver == drivers.Postgres && (m.sslMode == "require" || m.sslMode == "verify-full" || m.sslMode == "verify-ca") {
+	switch m.driver {
+	case drivers.Postgres:
+		if m.sslMode == "require" || m.sslMode == "verify-full" || m.sslMode == "verify-ca" {
+			inputs = []string{
+				m.sslCertInput.View(),
+				m.sslKeyInput.View(),
+				m.sslPasswordInput.View(),
+				m.sslRootcertInput.View(),
+			}
+		}
+	case drivers.Oracle:
 		inputs = []string{
-			m.sslCertInput.View(),
-			m.sslKeyInput.View(),
-			m.sslPasswordInput.View(),
-			m.sslRootcertInput.View(),
+			m.traceFileInput.View(),
+			m.sslVerifyInput.View(),
+			m.walletInput.View(),
 		}
 	}
 


### PR DESCRIPTION
# Oracle Driver

## Description

This PR introduces a new driver to dblab  and that is Oracle.

![Screenshot from 2024-05-28 23-44-27](https://github.com/danvergara/dblab/assets/12239167/ff268658-20c9-47a0-b3f1-f40cd4528434)

## Changes:
* Add a new object that implements the `databaseQuerier` and performs operations on a given Oracle database
* Add parsing to build a URL to connect with an Oracle database
* Add some tweaks to the `UI` and `navigation` queries to support Oracle
* Add a service to the `Compose` file for testing
* Add a way to pass parameters to connect with an Oracle database through the config file
* Add Oracle support to the form mini tui app

Fixes #110 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Added a new Oracle container to test the new feature out against it.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
