### PR TITLE
add a new description on new query params supported due to the sqlite drive change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,6 @@ build:
 	CGO_ENABLED=0 \
 	go build -o dblab .
 
-.PHONY: build-sqlite3
-## build-sqlite3: Builds the Go program with CGO_ENABLED enabled.
-build-sqlite3:
-	CGO_ENABLED=0 \
-	go build -o dblab .
-
 .PHONY: run
 ## run: Runs the application
 run: build
@@ -74,9 +68,13 @@ run-mysql-socket-url: build
 
 .PHONY: run-sqlite3
 ## run-sqlite3: Runs the application with a connection to sqlite3
-run-sqlite3: build-sqlite3
-	docker compose run --rm dblab-sqlite3
+run-sqlite3: build
 	./dblab --db db/dblab.db --driver sqlite
+
+.PHONY: run-sqlite3-url
+## run-sqlite3-url: Runs the application with a connection string to sqlite3
+run-sqlite3-url: build
+	./dblab --url 'file:db/dblab.db?_pragma=foreign_keys(1)&_time_format=sqlite'
 
 .PHONY: run-url
 ## run-url: Runs the app passing the url as parameter

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Connection URL scheme is also supported:
 ```sh
 $ dblab --url 'postgres://user:password@host:port/database?sslmode=[mode]'
 $ dblab --url 'mysql://user:password@tcp(host:port)/db'
-$ dblab --url 'file:test.db?cache=shared&mode=memory'
+$ dblab --url 'file:test.db?_pragma=foreign_keys(1)&_time_format=sqlite'
 $ dblab --url 'oracle://user:password@localhost:1521/db'
 ```
 

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -72,8 +72,11 @@ func BuildConnectionFromOpts(opts command.Options) (string, command.Options, err
 			return conn, opts, err
 		}
 
-		// this options is for sqlite.
+		// This options is for sqlite.
 		// For more information see https://github.com/mattn/go-sqlite3#connection-string.
+		// The sqlite driver is modernc.org/sqlite now, so the query params changed.
+		// mattn's driver and modernc.org's differ in the query paremeters they use to perform a connection.
+		// To know more about the connection and query paremeters see: https://pkg.go.dev/modernc.org/sqlite#Driver.Open
 		if strings.HasPrefix(opts.URL, "file:") {
 			opts.Driver = drivers.SQLite
 			return opts.URL, opts, nil


### PR DESCRIPTION
# Add a new description on new query params 

## Description

I realized that the query params for sqlite connection string are different than the ones that used to be supported because we change sqlite driver. I'm adding description on how to use them and reference to the new ones.

Fixes #220 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

I tested this out locally using the database file we provide.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
