### PR TITLE
Upgrade goreleaser support

### DIFF
--- a/.github/workflows/check-goreleaser.yml
+++ b/.github/workflows/check-goreleaser.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: "1.22"
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
         with:
           install-only: true
       - name: Check main config file 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,10 @@ jobs:
           echo ${{ env.CURRENT_VERSION }}
       - name: Run GoReleaser
         if: env.RELEASE_VERSION == env.CURRENT_VERSION
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          distribution: goreleaser
+          version: '~> v2'
           args: release -f .goreleaser.yaml --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GO_RELEASER_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,13 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
 before:
   hooks:
     - go mod tidy
@@ -45,7 +55,7 @@ brews:
 
     # Folder inside the repository to put the formula.
     # Default is the root folder.
-    folder: Formula
+    directory: Formula
 
     # Your app's homepage.
     # Default is empty.


### PR DESCRIPTION
# Bump the goreleaser action version to v6

## Description

The `goreleaser-check` workflow has been failing for months and the reason was that `goreleaser` released their version 2, so I went ahead and updated the `goreleaser` configuration file and  the `ci` workflow files.

