### PR TITLE
Mishandled expected error

### DIFF
--- a/pkg/gui/database_helpers.go
+++ b/pkg/gui/database_helpers.go
@@ -198,9 +198,6 @@ func (gui *Gui) nextPage(g *gocui.Gui, v *gocui.View) error {
 	}
 
 	totalPages := gui.c.TotalPages()
-	if err != nil {
-		return err
-	}
 
 	if err := gui.showIndex("index", page, totalPages); err != nil {
 		return err
@@ -222,9 +219,6 @@ func (gui *Gui) previousPage(g *gocui.Gui, v *gocui.View) error {
 	}
 
 	totalPages := gui.c.TotalPages()
-	if err != nil {
-		return err
-	}
 
 	if err := gui.showIndex("index", page, totalPages); err != nil {
 		return err


### PR DESCRIPTION
# Mishandled expected error

## Description

A user recently reported that he didn't like the way dblab handles error happening at getting the metadata of a table. The way it works right now is that dblab crashes and prints out the error. The expected behavior is that every error generated by queries are printed on the `rows`  view. So, I went ahead and made sure those errors are printed on the view mentioned above.

Fixes #227

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unfortunately, the gui package doesn't have a test suite. To test this out, I hard-coded a non-existent table. This is supposed to error out due to the table is no present in the database.

![Screenshot from 2024-07-17 21-55-00](https://github.com/user-attachments/assets/ae448482-10db-4746-b831-71c9e922290d)

Now, the expected error shows up on the `rows` table.

![Screenshot from 2024-07-17 21-09-18](https://github.com/user-attachments/assets/efc69e55-dbaf-476a-a685-476897b26cf9)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
