### PR TITLE
add a key binding to clear the query editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,8 @@ The `--db` flag is now optional (except for Oracle), meaning that the user will 
 ### Key Bindings
 | Key                                     | Description                           |
 |----------------------------------------|----------------------------------------|
-|<kbd>Ctrl+Space</kbd>                   | If the query panel is active, execute the query |
+|<kbd>Ctrl+Space</kbd>                   | If the query editor is active, execute the query |
+|<kbd>Ctrl+D</kbd>                       | Cleans the whole text from the query editor, when the editor is selected |
 |<kbd>Enter</kbd>                        | If the tables panel is active, list all the rows as a result set on the rows panel and display the structure of the table on the structure panel |
 |<kbd>Ctrl+S</kbd>                       | If the rows panel is active, switch to the schema panel. The opposite is true |
 |<kbd>Ctrl+T</kbd>                       | If the rows panel is active, switch to the constraints view. The opposite is true |

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -171,6 +171,8 @@ func (t *Tui) setupQueries() {
 			// switch to the list of tables page if Ctrl+H gets pressed.
 			t.app.SetFocus(t.aw.catalogPage)
 			return nil
+		case tcell.KeyCtrlD:
+			t.aw.queries.SetText("", true)
 		}
 		return event
 	})


### PR DESCRIPTION
# Add Ctrl+D to clear the query editor

## Description

I found myself running multiple queries earlier today and I realized that doing son multiple times is very tedious due to the limitations of the `TextArea` object from the `tview` library. The easiest way to start over is cleaning the whole text.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
