### PR TITLE
fix: cursor is not wrapping correctly for inputs when overflowing

### DIFF
--- a/pkg/form/update.go
+++ b/pkg/form/update.go
@@ -65,10 +65,10 @@ func updateStd(msg tea.Msg, m *Model) (tea.Model, tea.Cmd) {
 				m.cursor++
 			}
 
-			if m.cursor > len(inputs) {
+			if m.cursor > len(inputs)-1 {
 				m.cursor = 0
 			} else if m.cursor < 0 {
-				m.cursor = len(inputs)
+				m.cursor = len(inputs) - 1
 			}
 
 			for i := 0; i <= len(inputs)-1; i++ {
@@ -252,10 +252,10 @@ func updateSSLConn(msg tea.Msg, m *Model) (tea.Model, tea.Cmd) {
 				m.cursor++
 			}
 
-			if m.cursor > len(inputs) {
+			if m.cursor > len(inputs)-1 {
 				m.cursor = 0
 			} else if m.cursor < 0 {
-				m.cursor = len(inputs)
+				m.cursor = len(inputs) - 1
 			}
 
 			for i := 0; i <= len(inputs)-1; i++ {


### PR DESCRIPTION
## Description

fixing the #281 issue cursor is not wrapping correctly for inputs when overflowing.

Fixes #281

## Type of change
- Bug fix

## How Has This Been Tested?

since this is ui bug i have checked manully and it works fine for me.

