### PR TITLE
fix ssl connection params still showing after selecting disable in the ui

### DIFF
--- a/pkg/form/update.go
+++ b/pkg/form/update.go
@@ -208,15 +208,15 @@ func updateSSLMode(msg tea.Msg, m *Model) (tea.Model, tea.Cmd) {
 				m.sslMode = m.sqlServerSSLModes[m.cursor]
 			}
 
-			m.steps = 3
-			m.cursor = 0
-
 			switch m.driver {
 			case drivers.Postgres, drivers.Oracle, drivers.SQLServer, drivers.MySQL:
 				if m.sslMode == "disable" || m.sslMode == "false" {
 					return m, tea.Quit
 				}
 			}
+
+			m.steps = 3
+			m.cursor = 0
 
 			return m, nil
 		}


### PR DESCRIPTION
## Description
When selecting disable for ssl connection params it's still showing ssl connection params options.

Fixes #280

## Type of change

-Bug fix

## How Has This Been Tested?
- Tested manually
