### PR TITLE
fix flags logic at the root.go file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,7 +62,20 @@ func NewRootCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var opts command.Options
 			var err error
-			var kb command.TUIKeyBindings
+			// Default keybindings.
+			var kb = command.TUIKeyBindings{
+				RunQuery:    tcell.KeyCtrlSpace,
+				Structure:   tcell.KeyCtrlS,
+				Indexes:     tcell.KeyCtrlI,
+				Constraints: tcell.KeyCtrlT,
+				ClearEditor: tcell.KeyCtrlD,
+				Navigation: command.TUINavigationBindgins{
+					Up:    tcell.KeyCtrlK,
+					Down:  tcell.KeyCtrlJ,
+					Left:  tcell.KeyCtrlH,
+					Right: tcell.KeyCtrlL,
+				},
+			}
 
 			if cfg {
 				opts, err = config.Init(cfgName)
@@ -100,33 +113,6 @@ func NewRootCmd() *cobra.Command {
 					SSHKeyPassphrase:       sshKeyPassphrase,
 				}
 
-				// Default keybindings.
-				kb = command.TUIKeyBindings{
-					RunQuery:    tcell.KeyCtrlSpace,
-					Structure:   tcell.KeyCtrlS,
-					Indexes:     tcell.KeyCtrlI,
-					Constraints: tcell.KeyCtrlT,
-					ClearEditor: tcell.KeyCtrlD,
-					Navigation: command.TUINavigationBindgins{
-						Up:    tcell.KeyCtrlK,
-						Down:  tcell.KeyCtrlJ,
-						Left:  tcell.KeyCtrlH,
-						Right: tcell.KeyCtrlL,
-					},
-				}
-
-				// If the --keybindings flag is set, fill the keybindings with the ones fonud in the config file.
-				// This is safe to do even if they're missing in the config files, because the config package has default values for it.
-				if keybindings {
-					kb, err = config.SetupKeybindings()
-					if err != nil {
-						return err
-					}
-				}
-
-				// Set the keybindings values, either the default ones or the found in the config file.
-				opts.UpdateKeybindings(kb)
-
 				if form.IsEmpty(opts) {
 					opts, err = form.Run()
 					if err != nil {
@@ -134,6 +120,18 @@ func NewRootCmd() *cobra.Command {
 					}
 				}
 			}
+
+			// If the --keybindings flag is set, fill the keybindings with the ones fonud in the config file.
+			// This is safe to do even if they're missing in the config files, because the config package has default values for it.
+			if keybindings {
+				kb, err = config.SetupKeybindings()
+				if err != nil {
+					return err
+				}
+			}
+
+			// Set the keybindings values, either the default ones or the found in the config file.
+			opts.UpdateKeybindings(kb)
 
 			if err := connection.ValidateOpts(opts); err != nil {
 				return err


### PR DESCRIPTION
# Fix flags logic in the **cmd/root.go** file

## Description

Some user have reported some issues related to the lack of the default values for the keybindings in #269. I just found out that the `--config` and the `--keybdings` were not really independent, so I made sure they are now, and I made sure the keybindings are always set, no matter what.

Fixes #269 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I QA'd the changes manually.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
