### PR TITLE
Vim inspired query editor

### DIFF
--- a/.dblab.yaml
+++ b/.dblab.yaml
@@ -62,7 +62,6 @@ database:
     ssh-key-pass: "hiuwiewnc092"
 limit: 50
 keybindings:
-  execute-query: 'ctrl+e'
   next-tab: 'tab'
   prev-tab: 'shift+tab'
   end-of-line: '$'
@@ -73,6 +72,7 @@ keybindings:
     left: 'ctrl+h'
     right: 'ctrl+l'
   editor:
+    execute-query: 'ctrl+e'
     insert: 'i'
     normal: 'esc'
     up: 'k'

--- a/.dblab.yaml
+++ b/.dblab.yaml
@@ -72,3 +72,10 @@ keybindings:
     down: 'ctrl+j'
     left: 'ctrl+h'
     right: 'ctrl+l'
+  editor:
+    insert: 'i'
+    normal: 'esc'
+    up: 'k'
+    down: 'j'
+    left: 'h'
+    right: 'l'

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ site/
 
 # file to dump messages for debugging
 messages.log
+editor_messages.log
+results_messages.log

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ __Interactive client for PostgreSQL, MySQL, SQLite3, Oracle and SQL Server.__
     - [Configuration](#configuration)
         - [Key bindings configuration](#key-bindings-configuration) 
 - [Navigation](#navigation)
+    - [Query editor](#query-editor)
     - [Key Bindings](#key-bindings)
 - [Contribute](#contribute)
 - [License](#license)
@@ -46,6 +47,7 @@ application to work with local or remote PostgreSQL/MySQL/SQLite3/Oracle/SQL Ser
 - Cross-platform support for macOS/Linux/Windows (32/64-bit)
 - Simple installation (distributed as a single binary)
 - Zero dependencies.
+- Vim-style query editor (normal and insert modes, line-oriented editing commands).
 
 ## Installation
 
@@ -261,7 +263,9 @@ $ dblab --config --cfg-name "prod"
 
 #### Key bindings configuration
 
-Key bindings can be configured through the `.dblab.yaml` file. There is a field called `keybindings` where key bindings can be modified. By default, the keybindings are not loaded, so you need to use the `--keybindings` or `-k` flag to load them. See the example to see the full list of the key bindings subject to change. The file shows the default values. The list of the available key bindings belongs to the [bubbletea](https://github.com/charmbracelet/bubbletea) library. Specifically, see the [KeyNames map](https://github.com/charmbracelet/bubbletea/blob/1ed724a2d1316ace504f87a2f0bbbcc189d280f6/key.go#L15) for an accurate reference.
+Key bindings can be configured through the `.dblab.yaml` file. There is a field called `keybindings` where key bindings can be modified. Under `keybindings`, an `editor` section configures the Vim-style query editor (movement between normal and insert mode, cursor motion in normal mode, and the editor’s execute-query shortcut). By default, the keybindings are not loaded, so you need to use the `--keybindings` or `-k` flag to load them. See the example to see the full list of the key bindings subject to change. The file shows the default values. The list of the available key bindings belongs to the [bubbletea](https://github.com/charmbracelet/bubbletea) library. Specifically, see the [KeyNames map](https://github.com/charmbracelet/bubbletea/blob/1ed724a2d1316ace504f87a2f0bbbcc189d280f6/key.go#L15) for an accurate reference.
+
+**Deprecated:** the top-level `execute-query` field under `keybindings`. Use `execute-query` under `keybindings.editor` instead.
 
 #### .dblab.yaml example
 
@@ -336,7 +340,6 @@ database:
 # should be greater than 0, otherwise the app will error out
 limit: 50
 keybindings:
-  execute-query: 'ctrl+e'
   next-tab: 'tab'
   prev-tab: 'shift+tab'
   page-top: 'g'
@@ -348,6 +351,14 @@ keybindings:
     down: 'ctrl+j'
     left: 'ctrl+h'
     right: 'ctrl+l'
+  editor:
+    up: 'k'
+    down: 'j'
+    left: 'h'
+    right: 'l'
+    insert: 'i'
+    normal: 'esc'
+    execute-query: 'ctrl+e'
 ```
 
 Or for SQLite:
@@ -365,7 +376,9 @@ Only the `host` and `ssl` fields are optional. They default to `127.0.0.1` and `
 
 Key bindings are now configurable; see [Key bindings configuration](#key-bindings-configuration) to learn how to replace existing key bindings. It's worth noting that key bindings are only configurable through the configuration file; there are no flags to do so. If you don't replace them through the configuration file, the information below remains the same; otherwise, just replace the new key binding with the existing information for the default one.
 
-If the query panel is active, type the desired query and press <kbd>ctrl+e</kbd> to see the results on the rows panel below.
+### Query editor
+
+The query editor uses **normal** and **insert** modes (similar to Vim). When you focus the query editor, it starts in **normal** mode. Press <kbd>i</kbd> to enter insert mode and type or edit SQL; press <kbd>Escape</kbd> to return to normal mode (the cursor moves one character to the left, as in Vim). In insert mode, use the arrow keys to move the cursor; in normal mode, use <kbd>h</kbd>, <kbd>j</kbd>, <kbd>k</kbd>, and <kbd>l</kbd> instead (configurable in `.dblab.yaml` with `--keybindings` or `-k`; see [Key bindings configuration](#key-bindings-configuration)). In normal mode, <kbd>dd</kbd> deletes the current line, <kbd>yy</kbd> yanks the current line into an internal register, <kbd>p</kbd> pastes that line after the current line, and <kbd>x</kbd> deletes the character under the cursor. <kbd>0</kbd> and <kbd>$</kbd> move to the beginning or end of the current line in the query buffer. Press <kbd>ctrl+e</kbd> to execute the query (this uses the `keybindings.editor.execute-query` binding); whitespace-only queries are ignored.
 
 Otherwise, you might be located at the tables panel, where you can navigate using the arrows <kbd>Up</kbd> and <kbd>Down</kbd> (or the keys <kbd>k</kbd> and <kbd>j</kbd> respectively). If you want to see the rows of a table, press <kbd>Enter</kbd>. To see the schema of a table, locate yourself on the `tables` panel and press <kbd>tab</kbd> to switch to the `columns` panel, then use <kbd>shift+tab</kbd> to switch back.
 
@@ -385,27 +398,32 @@ When navigating query result sets, the cell will be highlighted so the user can 
 ### Key Bindings
 | Key                                    | Description                           |
 |----------------------------------------|----------------------------------------|
-|<kbd>ctrl+e</kbd>                       | If the query editor is active, execute the query |
-|<kbd>Ctrl+D</kbd>                       | Clears all text from the query editor when it is selected |
-|<kbd>Enter</kbd>                        | If the tables panel is active, list all rows as a result set on the rows panel and display the structure of the table on the structure panel |
-|<kbd>tab</kbd>                          | If the result set panel is active, press tab to navigate to the next metadata tab |
-|<kbd>shift+tab</kbd>                    | If the result set panel is active, press shift+tab to navigate to the previous metadata tab |
+|<kbd>ctrl+e</kbd>                       | If the query editor is focused, execute the query (also works in insert and normal mode) |
+|<kbd>i</kbd>                            | If the query editor is focused in normal mode, enter insert mode |
+|<kbd>Escape</kbd>                       | If the query editor is focused in insert mode, return to normal mode |
+|<kbd>dd</kbd>                           | If the query editor is focused in normal mode, delete the current line |
+|<kbd>yy</kbd>                           | If the query editor is focused in normal mode, yank the current line |
+|<kbd>p</kbd>                            | If the query editor is focused in normal mode, paste the yanked or deleted line after the current line |
+|<kbd>x</kbd>                            | If the query editor is focused in normal mode, delete the character under the cursor |
+|<kbd>Enter</kbd>                        | If the tables panel is focused, list all rows as a result set on the rows panel and display the structure of the table on the structure panel |
+|<kbd>tab</kbd>                          | If the result set panel is focused, press tab to navigate to the next metadata tab |
+|<kbd>shift+tab</kbd>                    | If the result set panel is focused, press shift+tab to navigate to the previous metadata tab |
 |<kbd>Ctrl+H</kbd>                       | Toggle to the panel on the left |
 |<kbd>Ctrl+J</kbd>                       | Toggle to the panel below |
 |<kbd>Ctrl+K</kbd>                       | Toggle to the panel above |
 |<kbd>Ctrl+L</kbd>                       | Toggle to the panel on the right |
-|<kbd>Arrow Up</kbd>                     | Vertical scrolling on the panel. Views: rows, table, constraints, structure, and indexes |
-|<kbd>k</kbd>                            | Vertical scrolling on the panel. Views: rows, table, constraints, structure, and indexes |
-|<kbd>Arrow Down</kbd>                   | Vertical scrolling on the panel. Views: rows, table, constraints, structure, and indexes |
-|<kbd>j</kbd>                            | Vertical scrolling on the panel. Views: rows, table, constraints, structure, and indexes |
-|<kbd>Arrow Right</kbd>                  | Horizontal scrolling on the panel. Views: rows, constraints, structure, and indexes |
-|<kbd>l</kbd>                            | Horizontal scrolling on the panel. Views: rows, constraints, structure, and indexes |
-|<kbd>Arrow Left</kbd>                   | Horizontal scrolling on the panel. Views: rows, constraints, structure, and indexes |
-|<kbd>h</kbd>                            | Horizontal scrolling on the panel. Views: rows, constraints, structure, and indexes |
-|<kbd>g</kbd>                            | Move cursor to the top of the panel's dataset. Views: rows, constraints, structure, and indexes |
-|<kbd>G</kbd>                            | Move cursor to the bottom of the panel's dataset. Views: rows, constraints, structure, and indexes |
-|<kbd>0</kbd>                            | Naviagate all the way to the left of the table. Views: rows, constraints, structure, and indexes |
-|<kbd>$</kbd>                            | Naviagate all the way to the right of the table. Views: rows, constraints, structure, and indexes |
+|<kbd>Arrow Up</kbd>                     | If the query editor is focused in insert mode, move the cursor up. If the results panel is focused, navigate the table upward (all tabs on the results panel). |
+|<kbd>k</kbd>                            | If the query editor is focused in normal mode, move the cursor up. If the results panel is focused, navigate the table upward (all tabs on the results panel). |
+|<kbd>Arrow Down</kbd>                   | If the query editor is focused in insert mode, move the cursor down. If the results panel is focused, navigate the table downward (all tabs on the results panel). |
+|<kbd>j</kbd>                            | If the query editor is focused in normal mode, move the cursor down. If the results panel is focused, navigate the table downward (all tabs on the results panel). |
+|<kbd>Arrow Right</kbd>                  | If the query editor is focused in insert mode, move the cursor right. If the results panel is focused, navigate the table to the right (all tabs on the results panel). |
+|<kbd>l</kbd>                            | If the query editor is focused in normal mode, move the cursor right. If the results panel is focused, navigate the table to the right (all tabs on the results panel). |
+|<kbd>Arrow Left</kbd>                   | If the query editor is focused in insert mode, move the cursor left. If the results panel is focused, navigate the table to the left (all tabs on the results panel). |
+|<kbd>h</kbd>                            | If the query editor is focused in normal mode, move the cursor left. If the results panel is focused, navigate the table to the left (all tabs on the results panel). |
+|<kbd>g</kbd>                            | If the results panel is focused, move to the top of the dataset (all tabs on the results panel). |
+|<kbd>G</kbd>                            | If the results panel is focused, move to the bottom of the dataset (all tabs on the results panel). |
+|<kbd>0</kbd>                            | If the query editor is focused in normal mode, move to the start of the current line. If the results panel is focused, move to the left edge of the row (all tabs on the results panel). |
+|<kbd>$</kbd>                            | If the query editor is focused in normal mode, move to the end of the current line. If the results panel is focused, move to the right edge of the row (all tabs on the results panel). |
 |<kbd>Ctrl+c</kbd>                       | Quit |
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ $ dblab --config --cfg-name "prod"
 
 #### Key bindings configuration
 
-Key bindings can be configured through the `.dblab.yaml` file. There is a field called `keybindings` where key bindings can be modified. By default, the keybindings are not loaded, so you need to use the `--keybindings` or `-k` flag to load them. See the example to see the full list of the key bindings subject to change. The file shows the default values. The list of the available key bindings belongs to the [tcell](https://github.com/gdamore/tcell) library. Specifically, see the [KeyNames map](https://github.com/gdamore/tcell/blob/781586687ddb57c9d44727dc9320340c4d049b11/key.go#L83) for an accurate reference.
+Key bindings can be configured through the `.dblab.yaml` file. There is a field called `keybindings` where key bindings can be modified. By default, the keybindings are not loaded, so you need to use the `--keybindings` or `-k` flag to load them. See the example to see the full list of the key bindings subject to change. The file shows the default values. The list of the available key bindings belongs to the [bubbletea](https://github.com/charmbracelet/bubbletea) library. Specifically, see the [KeyNames map](https://github.com/charmbracelet/bubbletea/blob/1ed724a2d1316ace504f87a2f0bbbcc189d280f6/key.go#L15) for an accurate reference.
 
 #### .dblab.yaml example
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,7 +112,7 @@ func NewRootCmd() *cobra.Command {
 			// If the --keybindings flag is set, fill the keybindings with the ones fonud in the config file.
 			// This is safe to do even if they're missing in the config files, because the config package has default values for it.
 			if keybindings {
-				kb, err = config.SetupKeybindings()
+				kb, err = config.SetupKeyMap()
 				if err != nil {
 					return err
 				}

--- a/docs/features.md
+++ b/docs/features.md
@@ -3,3 +3,4 @@ The key features are:
   * Cross-platform support for macOS/Linux/Windows (32/64-bit)  
   * Simple installation (distributed as a single binary)  
   * Zero dependencies.  
+  * Vim-style query editor (normal and insert modes, line-oriented editing commands).  

--- a/docs/tutorials/navigation.md
+++ b/docs/tutorials/navigation.md
@@ -1,7 +1,10 @@
 One of the main features of dblab is its simple but very useful UI for interacting with your database.  
 ![dblab](https://raw.githubusercontent.com/danvergara/dblab/main/assets/tutorials/images/full-ui.png){ width="700" : .center }  
 
-If the query panel is active, type the desired query and press <kbd>ctrl+e</kbd> to see the results on the rows panel below.
+### Query editor
+
+The query editor uses **normal** and **insert** modes (similar to Vim). When you focus the query editor, it starts in **normal** mode. Press <kbd>i</kbd> to enter insert mode and type or edit SQL; press <kbd>Escape</kbd> to return to normal mode (the cursor moves one character to the left, as in Vim). In insert mode, use the arrow keys to move the cursor; in normal mode, use <kbd>h</kbd>, <kbd>j</kbd>, <kbd>k</kbd>, and <kbd>l</kbd> instead (configurable in `.dblab.yaml` with `--keybindings` or `-k`; see [Key bindings configuration](../usage.md#key-bindings-configuration)). In normal mode, <kbd>dd</kbd> deletes the current line, <kbd>yy</kbd> yanks the current line into an internal register, <kbd>p</kbd> pastes that line after the current line, and <kbd>x</kbd> deletes the character under the cursor. <kbd>0</kbd> and <kbd>$</kbd> move to the beginning or end of the current line in the query buffer. Press <kbd>ctrl+e</kbd> to execute the query (this uses the `keybindings.editor.execute-query` binding); whitespace-only queries are ignored.
+
 Otherwise, you might be located at the tables panel, where you can navigate using the arrows <kbd>Up</kbd> and <kbd>Down</kbd> (or the keys <kbd>k</kbd> and <kbd>j</kbd> respectively). If you want to see the rows of a table, press <kbd>Enter</kbd>. To see the schema of a table, locate yourself on the `tables` panel and press <kbd>tab</kbd> to switch to the `columns` panel, then use <kbd>shift+tab</kbd> to switch back.
 
 Now, there's a menu to navigate between hidden views by just clicking on the desired options:
@@ -19,8 +22,8 @@ In order to be able to see the information for `Columns`, `Indexes`, or `Constra
 
 To navigate there you can use:
 
-- <kbd>tab</kbd>: If the result set panel is active, press tab to navigate to the next metadata tab.
-- <kbd>shift+tab</kbd>: If the result set panel is active, press shift+tab to navigate to the previous metadata tab.
+- <kbd>tab</kbd>: If the result set panel is focused, press tab to navigate to the next metadata tab.
+- <kbd>shift+tab</kbd>: If the result set panel is focused, press shift+tab to navigate to the previous metadata tab.
  
 Once the correct name is highlighted in the left menu, press <kbd>Enter</kbd> to select the table.
 Now you can navigate to the different panels to see the related information.
@@ -38,25 +41,30 @@ When navigating query result sets, the cell will be highlighted so the user can 
 ### Key Bindings
 | Key                                    | Description                           |
 |----------------------------------------|----------------------------------------|
-|<kbd>ctrl+e</kbd>                       | If the query editor is active, execute the query |
-|<kbd>Ctrl+D</kbd>                       | Clears all text from the query editor when it is selected |
-|<kbd>Enter</kbd>                        | If the tables panel is active, list all rows as a result set on the rows panel and display the structure of the table on the structure panel |
-|<kbd>tab</kbd>                          | If the result set panel is active, press tab to navigate to the next metadata tab |
-|<kbd>shift+tab</kbd>                    | If the result set panel is active, press shift+tab to navigate to the previous metadata tab |
+|<kbd>ctrl+e</kbd>                       | If the query editor is focused, execute the query (also works in insert and normal mode) |
+|<kbd>i</kbd>                            | If the query editor is focused in normal mode, enter insert mode |
+|<kbd>Escape</kbd>                       | If the query editor is focused in insert mode, return to normal mode |
+|<kbd>dd</kbd>                           | If the query editor is focused in normal mode, delete the current line |
+|<kbd>yy</kbd>                           | If the query editor is focused in normal mode, yank the current line |
+|<kbd>p</kbd>                            | If the query editor is focused in normal mode, paste the yanked or deleted line after the current line |
+|<kbd>x</kbd>                            | If the query editor is focused in normal mode, delete the character under the cursor |
+|<kbd>Enter</kbd>                        | If the tables panel is focused, list all rows as a result set on the rows panel and display the structure of the table on the structure panel |
+|<kbd>tab</kbd>                          | If the result set panel is focused, press tab to navigate to the next metadata tab |
+|<kbd>shift+tab</kbd>                    | If the result set panel is focused, press shift+tab to navigate to the previous metadata tab |
 |<kbd>Ctrl+H</kbd>                       | Toggle to the panel on the left |
 |<kbd>Ctrl+J</kbd>                       | Toggle to the panel below |
 |<kbd>Ctrl+K</kbd>                       | Toggle to the panel above |
 |<kbd>Ctrl+L</kbd>                       | Toggle to the panel on the right |
-|<kbd>Arrow Up</kbd>                     | Vertical scrolling on the panel. Views: rows, table, constraints, structure, and indexes |
-|<kbd>k</kbd>                            | Vertical scrolling on the panel. Views: rows, table, constraints, structure, and indexes |
-|<kbd>Arrow Down</kbd>                   | Vertical scrolling on the panel. Views: rows, table, constraints, structure, and indexes |
-|<kbd>j</kbd>                            | Vertical scrolling on the panel. Views: rows, table, constraints, structure, and indexes |
-|<kbd>Arrow Right</kbd>                  | Horizontal scrolling on the panel. Views: rows, constraints, structure, and indexes |
-|<kbd>l</kbd>                            | Horizontal scrolling on the panel. Views: rows, constraints, structure, and indexes |
-|<kbd>Arrow Left</kbd>                   | Horizontal scrolling on the panel. Views: rows, constraints, structure, and indexes |
-|<kbd>h</kbd>                            | Horizontal scrolling on the panel. Views: rows, constraints, structure, and indexes |
-|<kbd>g</kbd>                            | Move cursor to the top of the panel's dataset. Views: rows, constraints, structure, and indexes |
-|<kbd>G</kbd>                            | Move cursor to the bottom of the panel's dataset. Views: rows, constraints, structure, and indexes |
-|<kbd>0</kbd>                            | Naviagate all the way to the left of the table. Views: rows, constraints, structure, and indexes |
-|<kbd>$</kbd>                            | Naviagate all the way to the right of the table. Views: rows, constraints, structure, and indexes |
+|<kbd>Arrow Up</kbd>                     | If the query editor is focused in insert mode, move the cursor up. If the results panel is focused, navigate the table upward (all tabs on the results panel). |
+|<kbd>k</kbd>                            | If the query editor is focused in normal mode, move the cursor up. If the results panel is focused, navigate the table upward (all tabs on the results panel). |
+|<kbd>Arrow Down</kbd>                   | If the query editor is focused in insert mode, move the cursor down. If the results panel is focused, navigate the table downward (all tabs on the results panel). |
+|<kbd>j</kbd>                            | If the query editor is focused in normal mode, move the cursor down. If the results panel is focused, navigate the table downward (all tabs on the results panel). |
+|<kbd>Arrow Right</kbd>                  | If the query editor is focused in insert mode, move the cursor right. If the results panel is focused, navigate the table to the right (all tabs on the results panel). |
+|<kbd>l</kbd>                            | If the query editor is focused in normal mode, move the cursor right. If the results panel is focused, navigate the table to the right (all tabs on the results panel). |
+|<kbd>Arrow Left</kbd>                   | If the query editor is focused in insert mode, move the cursor left. If the results panel is focused, navigate the table to the left (all tabs on the results panel). |
+|<kbd>h</kbd>                            | If the query editor is focused in normal mode, move the cursor left. If the results panel is focused, navigate the table to the left (all tabs on the results panel). |
+|<kbd>g</kbd>                            | If the results panel is focused, move to the top of the dataset (all tabs on the results panel). |
+|<kbd>G</kbd>                            | If the results panel is focused, move to the bottom of the dataset (all tabs on the results panel). |
+|<kbd>0</kbd>                            | If the query editor is focused in normal mode, move to the start of the current line. If the results panel is focused, move to the left edge of the row (all tabs on the results panel). |
+|<kbd>$</kbd>                            | If the query editor is focused in normal mode, move to the end of the current line. If the results panel is focused, move to the right edge of the row (all tabs on the results panel). |
 |<kbd>Ctrl+c</kbd>                       | Quit |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,45 +70,56 @@ Use "dblab [command] --help" for more information about a command.
 
 ## Navigation
 
-If the query panel is active, type the desired query and press <kbd>ctrl+e</kbd> to see the results on the rows panel below.
+Key bindings are now configurable; see [Key bindings configuration](#key-bindings-configuration) to learn how to replace existing key bindings. It's worth noting that key bindings are only configurable through the configuration file; there are no flags to do so. If you don't replace them through the configuration file, the information below remains the same; otherwise, just replace the new key binding with the existing information for the default one.
+
+### Query editor
+
+The query editor uses **normal** and **insert** modes (similar to Vim). When you focus the query editor, it starts in **normal** mode. Press <kbd>i</kbd> to enter insert mode and type or edit SQL; press <kbd>Escape</kbd> to return to normal mode (the cursor moves one character to the left, as in Vim). In insert mode, use the arrow keys to move the cursor; in normal mode, use <kbd>h</kbd>, <kbd>j</kbd>, <kbd>k</kbd>, and <kbd>l</kbd> instead (configurable in `.dblab.yaml` with `--keybindings` or `-k`; see [Key bindings configuration](#key-bindings-configuration)). In normal mode, <kbd>dd</kbd> deletes the current line, <kbd>yy</kbd> yanks the current line into an internal register, <kbd>p</kbd> pastes that line after the current line, and <kbd>x</kbd> deletes the character under the cursor. <kbd>0</kbd> and <kbd>$</kbd> move to the beginning or end of the current line in the query buffer. Press <kbd>ctrl+e</kbd> to execute the query (this uses the `keybindings.editor.execute-query` binding); whitespace-only queries are ignored.
 
 Otherwise, you might be located at the tables panel, where you can navigate using the arrows <kbd>Up</kbd> and <kbd>Down</kbd> (or the keys <kbd>k</kbd> and <kbd>j</kbd> respectively). If you want to see the rows of a table, press <kbd>Enter</kbd>. To see the schema of a table, locate yourself on the `tables` panel and press <kbd>tab</kbd> to switch to the `columns` panel, then use <kbd>shift+tab</kbd> to switch back.
-
-The `--db` flag is now optional (except for Oracle), meaning that the user will be able to see the list of databases they have access to. The regular list of tables will be replaced with a tree structure showing a list of databases and their respective list of tables, branching off each database. Due to the nature of the vast majority of DBMSs that don't allow cross-database queries, dblab has to open an independent connection for each database. The side effect of this decision is that the user has to press `Enter` on the specific database of interest. An indicator showing the current active database will appear at the bottom-right of the screen. To change the focus, just hit enter on another database. Once a database is selected, the usual behavior of inspecting tables remains the same.
-
-<img src="https://raw.githubusercontent.com/danvergara/dblab/main/screenshots/tree-view.png" />
-
-Now, there's a menu to navigate between hidden views by just clicking on the desired options:
 
 ![Alt Text](https://raw.githubusercontent.com/danvergara/dblab/main/screenshots/rows-view.png){ width="700" : .center }
 ![Alt Text](https://raw.githubusercontent.com/danvergara/dblab/main/screenshots/structure-view.png){ width="700" : .center }
 ![Alt Text](https://raw.githubusercontent.com/danvergara/dblab/main/screenshots/constraints-view.png){ width="700" : .center }
 ![Alt Text](https://raw.githubusercontent.com/danvergara/dblab/main/screenshots/indexes-view.png){ width="700" : .center }
 
+The navigation buttons were removed since they are too slow to navigate the content of a table effectively. The user is better off typing a `SELECT` statement with proper `OFFSET` and `LIMIT`.
+
+The `--db` flag is now optional (except for Oracle), meaning that the user will be able to see the list of databases they have access to. The regular list of tables will be replaced with a tree structure showing a list of databases and their respective list of tables, branching off each database. Due to the nature of the vast majority of DBMSs that don't allow cross-database queries, dblab has to open an independent connection for each database. The side effect of this decision is that the user has to press `Enter` on the specific database of interest. An indicator showing the current active database will appear at the bottom-right of the screen. To change the focus, just hit enter on another database. Once a database is selected, the usual behavior of inspecting tables remains the same.
+
+<img src="https://raw.githubusercontent.com/danvergara/dblab/main/screenshots/tree-view.png" />
+
 When navigating query result sets, the cell will be highlighted so the user can see which table cell is selected. This is important because you can press the `Enter` key on a cell of interest to copy its content.
 
 ### Key Bindings
 | Key                                    | Description                           |
 |----------------------------------------|----------------------------------------|
-|<kbd>ctrl+e</kbd>                       | If the query editor is active, execute the query |
-|<kbd>Ctrl+D</kbd>                       | Clears all text from the query editor when it is selected |
-|<kbd>Enter</kbd>                        | If the tables panel is active, list all rows as a result set on the rows panel and display the structure of the table on the structure panel |
-|<kbd>tab</kbd>                          | If the result set panel is active, press tab to navigate to the next metadata tab |
-|<kbd>shift+tab</kbd>                    | If the result set panel is active, press shift+tab to navigate to the previous metadata tab |
+|<kbd>ctrl+e</kbd>                       | If the query editor is focused, execute the query (also works in insert and normal mode) |
+|<kbd>i</kbd>                            | If the query editor is focused in normal mode, enter insert mode |
+|<kbd>Escape</kbd>                       | If the query editor is focused in insert mode, return to normal mode |
+|<kbd>dd</kbd>                           | If the query editor is focused in normal mode, delete the current line |
+|<kbd>yy</kbd>                           | If the query editor is focused in normal mode, yank the current line |
+|<kbd>p</kbd>                            | If the query editor is focused in normal mode, paste the yanked or deleted line after the current line |
+|<kbd>x</kbd>                            | If the query editor is focused in normal mode, delete the character under the cursor |
+|<kbd>Enter</kbd>                        | If the tables panel is focused, list all rows as a result set on the rows panel and display the structure of the table on the structure panel |
+|<kbd>tab</kbd>                          | If the result set panel is focused, press tab to navigate to the next metadata tab |
+|<kbd>shift+tab</kbd>                    | If the result set panel is focused, press shift+tab to navigate to the previous metadata tab |
 |<kbd>Ctrl+H</kbd>                       | Toggle to the panel on the left |
 |<kbd>Ctrl+J</kbd>                       | Toggle to the panel below |
 |<kbd>Ctrl+K</kbd>                       | Toggle to the panel above |
 |<kbd>Ctrl+L</kbd>                       | Toggle to the panel on the right |
-|<kbd>Arrow Up</kbd>                     | Vertical scrolling on the panel. Views: rows, table, constraints, structure, and indexes |
-|<kbd>k</kbd>                            | Vertical scrolling on the panel. Views: rows, table, constraints, structure, and indexes |
-|<kbd>Arrow Down</kbd>                   | Vertical scrolling on the panel. Views: rows, table, constraints, structure, and indexes |
-|<kbd>j</kbd>                            | Vertical scrolling on the panel. Views: rows, table, constraints, structure, and indexes |
-|<kbd>Arrow Right</kbd>                  | Horizontal scrolling on the panel. Views: rows, constraints, structure, and indexes |
-|<kbd>l</kbd>                            | Horizontal scrolling on the panel. Views: rows, constraints, structure, and indexes |
-|<kbd>Arrow Left</kbd>                   | Horizontal scrolling on the panel. Views: rows, constraints, structure, and indexes |
-|<kbd>h</kbd>                            | Horizontal scrolling on the panel. Views: rows, constraints, structure, and indexes |
-|<kbd>g</kbd>                            | Move cursor to the top of the panel's dataset. Views: rows, constraints, structure, and indexes |
-|<kbd>G</kbd>                            | Move cursor to the bottom of the panel's dataset. Views: rows, constraints, structure, and indexes |
+|<kbd>Arrow Up</kbd>                     | If the query editor is focused in insert mode, move the cursor up. If the results panel is focused, navigate the table upward (all tabs on the results panel). |
+|<kbd>k</kbd>                            | If the query editor is focused in normal mode, move the cursor up. If the results panel is focused, navigate the table upward (all tabs on the results panel). |
+|<kbd>Arrow Down</kbd>                   | If the query editor is focused in insert mode, move the cursor down. If the results panel is focused, navigate the table downward (all tabs on the results panel). |
+|<kbd>j</kbd>                            | If the query editor is focused in normal mode, move the cursor down. If the results panel is focused, navigate the table downward (all tabs on the results panel). |
+|<kbd>Arrow Right</kbd>                  | If the query editor is focused in insert mode, move the cursor right. If the results panel is focused, navigate the table to the right (all tabs on the results panel). |
+|<kbd>l</kbd>                            | If the query editor is focused in normal mode, move the cursor right. If the results panel is focused, navigate the table to the right (all tabs on the results panel). |
+|<kbd>Arrow Left</kbd>                   | If the query editor is focused in insert mode, move the cursor left. If the results panel is focused, navigate the table to the left (all tabs on the results panel). |
+|<kbd>h</kbd>                            | If the query editor is focused in normal mode, move the cursor left. If the results panel is focused, navigate the table to the left (all tabs on the results panel). |
+|<kbd>g</kbd>                            | If the results panel is focused, move to the top of the dataset (all tabs on the results panel). |
+|<kbd>G</kbd>                            | If the results panel is focused, move to the bottom of the dataset (all tabs on the results panel). |
+|<kbd>0</kbd>                            | If the query editor is focused in normal mode, move to the start of the current line. If the results panel is focused, move to the left edge of the row (all tabs on the results panel). |
+|<kbd>$</kbd>                            | If the query editor is focused in normal mode, move to the end of the current line. If the results panel is focused, move to the right edge of the row (all tabs on the results panel). |
 |<kbd>Ctrl+c</kbd>                       | Quit |
 
 
@@ -272,8 +283,9 @@ dblab --config --cfg-name "prod"
 
 #### Key bindings configuration
 
-Key bindings can be configured through the `.dblab.yaml` file. There is a field called `keybindings` where key bindings can be modified. By default, the keybindings are not loaded, so you need to use the `--keybindings` or `-k` flag to load them. See the example to see the full list of the key bindings subject to change. The file shows the default values. The list of the available key bindings belongs to the [tcell](https://github.com/gdamore/tcell) library. Specifically, see the [KeyNames map](https://github.com/gdamore/tcell/blob/781586687ddb57c9d44727dc9320340c4d049b11/key.go#L83) for an accurate reference.
+Key bindings can be configured through the `.dblab.yaml` file. There is a field called `keybindings` where key bindings can be modified. Under `keybindings`, an `editor` section configures the Vim-style query editor (movement between normal and insert mode, cursor motion in normal mode, and the editor's execute-query shortcut). By default, the keybindings are not loaded, so you need to use the `--keybindings` or `-k` flag to load them. See the example to see the full list of the key bindings subject to change. The file shows the default values. The list of the available key bindings belongs to the [bubbletea](https://github.com/charmbracelet/bubbletea) library. Specifically, see the [KeyNames map](https://github.com/charmbracelet/bubbletea/blob/1ed724a2d1316ace504f87a2f0bbbcc189d280f6/key.go#L15) for an accurate reference.
 
+**Deprecated:** the top-level `execute-query` field under `keybindings`. Use `execute-query` under `keybindings.editor` instead.
 
 #### .dblab.yaml example
 
@@ -348,16 +360,25 @@ database:
 # should be greater than 0, otherwise the app will error out
 limit: 50
 keybindings:
-  execute-query: 'ctrl+e'
   next-tab: 'tab'
   prev-tab: 'shift+tab'
   page-top: 'g'
   page-bottom: 'G'
+  end-of-line: '$'
+  beginning-of-line: '0'
   navigation:
     up: 'ctrl+k'
     down: 'ctrl+j'
     left: 'ctrl+h'
     right: 'ctrl+l'
+  editor:
+    up: 'k'
+    down: 'j'
+    left: 'h'
+    right: 'l'
+    insert: 'i'
+    normal: 'esc'
+    execute-query: 'ctrl+e'
 ```
 
 Or for SQLite:

--- a/pkg/bubbletui/bubbletui.go
+++ b/pkg/bubbletui/bubbletui.go
@@ -154,14 +154,14 @@ type Model struct {
 	editorWidth           int
 
 	// Key Bindings.
-	bindings *command.TUIKeyBindings
+	bindings *command.TUIKeyMap
 
 	footer string
 
 	dump io.Writer
 }
 
-func NewModel(c *client.Client, kb *command.TUIKeyBindings) (*Model, error) {
+func NewModel(c *client.Client, kb *command.TUIKeyMap) (*Model, error) {
 	var dump *os.File
 	if _, ok := os.LookupEnv("DBLAB_DEBUG"); ok {
 		var err error

--- a/pkg/bubbletui/editor.go
+++ b/pkg/bubbletui/editor.go
@@ -26,10 +26,12 @@ type executeQueryMsg struct {
 }
 
 type Editor struct {
-	editor   textarea.Model
-	bindings *command.TUIKeyMap
-	mode     Mode
-	dump     io.Writer
+	editor     textarea.Model
+	bindings   *command.TUIKeyMap
+	mode       Mode
+	register   string
+	pendingCmd string
+	dump       io.Writer
 }
 
 func NewEditor(kb *command.TUIKeyMap) Editor {
@@ -92,6 +94,43 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 
 		switch e.mode {
 		case NormalMode:
+			char := msg.String()
+			if e.pendingCmd != "" {
+				switch e.pendingCmd {
+				case "d":
+					if char == "d" {
+						e.deleteCurrentLine()
+					}
+					e.pendingCmd = ""
+					return e, nil
+
+				case "y":
+					if char == "y" {
+						e.yankCurrentLine()
+					}
+					e.pendingCmd = ""
+					return e, nil
+				}
+			}
+
+			switch char {
+			case "d", "y":
+				e.pendingCmd = char
+				return e, nil
+			case "p":
+				e.pasteAfter()
+				return e, nil
+			case "x":
+				e.editor, cmd = e.editor.Update(tea.KeyMsg{Type: tea.KeyDelete})
+				return e, cmd
+			case "0":
+				e.editor, cmd = e.editor.Update(tea.KeyMsg{Type: tea.KeyHome})
+				return e, cmd
+			case "$":
+				e.editor, cmd = e.editor.Update(tea.KeyMsg{Type: tea.KeyEnd})
+				return e, cmd
+			}
+
 			switch {
 			case key.Matches(msg, e.bindings.Editor.Insert):
 				e.mode = InsertMode
@@ -134,4 +173,40 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 
 func (e Editor) View() string {
 	return e.editor.View()
+}
+
+func (e *Editor) yankCurrentLine() {
+	lines := strings.Split(e.editor.Value(), "\n")
+	row := e.editor.Line()
+
+	if row >= 0 && row < len(lines) {
+		e.register = lines[row]
+	}
+}
+
+func (e *Editor) deleteCurrentLine() {
+	lines := strings.Split(e.editor.Value(), "\n")
+	row := e.editor.Line()
+
+	if row >= 0 && row < len(lines) {
+		e.register = lines[row]
+
+		lines = append(lines[:row], lines[row+1:]...)
+
+		e.editor.SetValue(strings.Join(lines, "\n"))
+	}
+}
+
+func (e *Editor) pasteAfter() {
+	if e.register == "" {
+		return
+	}
+
+	lines := strings.Split(e.editor.Value(), "\n")
+	row := e.editor.Line()
+
+	if row >= 0 && row < len(lines) {
+		lines = append(lines[:row+1], append([]string{e.register}, lines[row+1:]...)...)
+		e.editor.SetValue(strings.Join(lines, "\n"))
+	}
 }

--- a/pkg/bubbletui/editor.go
+++ b/pkg/bubbletui/editor.go
@@ -160,7 +160,6 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 			case key.Matches(msg, e.bindings.Editor.Normal):
 				e.mode = NormalMode
 				e.editor.Cursor.SetMode(cursor.CursorStatic)
-				// Optional: move back one space on escape
 				e.editor, _ = e.editor.Update(tea.KeyMsg{Type: tea.KeyLeft})
 				return e, nil
 			}

--- a/pkg/bubbletui/editor.go
+++ b/pkg/bubbletui/editor.go
@@ -17,8 +17,8 @@ import (
 type Mode int
 
 const (
-	NormalMode Mode = iota // 0
-	InsertMode             // 1
+	NormalMode Mode = iota
+	InsertMode
 )
 
 type executeQueryMsg struct {

--- a/pkg/bubbletui/editor.go
+++ b/pkg/bubbletui/editor.go
@@ -79,7 +79,7 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		if key.Matches(msg, e.bindings.ExecuteQuery) {
+		if key.Matches(msg, e.bindings.Editor.ExecuteQuery) {
 			query := e.editor.Value()
 			if strings.TrimSpace(query) == "" {
 				return e, nil

--- a/pkg/bubbletui/editor.go
+++ b/pkg/bubbletui/editor.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/cursor"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
@@ -13,17 +14,25 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
+type Mode int
+
+const (
+	NormalMode Mode = iota // 0
+	InsertMode             // 1
+)
+
 type executeQueryMsg struct {
 	Query string
 }
 
 type Editor struct {
 	editor   textarea.Model
-	bindings *command.TUIKeyBindings
+	bindings *command.TUIKeyMap
+	mode     Mode
 	dump     io.Writer
 }
 
-func NewEditor(kb *command.TUIKeyBindings) Editor {
+func NewEditor(kb *command.TUIKeyMap) Editor {
 	var dump *os.File
 	if _, ok := os.LookupEnv("DBLAB_DEBUG"); ok {
 		var err error
@@ -68,8 +77,7 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		switch {
-		case key.Matches(msg, e.bindings.ExecuteQuery):
+		if key.Matches(msg, e.bindings.ExecuteQuery) {
 			query := e.editor.Value()
 			if strings.TrimSpace(query) == "" {
 				return e, nil
@@ -82,9 +90,45 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 			return e, fireQueryCmd
 		}
 
-		e.editor, cmd = e.editor.Update(msg)
+		switch e.mode {
+		case NormalMode:
+			switch {
+			case key.Matches(msg, e.bindings.Editor.Insert):
+				e.mode = InsertMode
+				e.editor.Cursor.SetMode(cursor.CursorBlink)
+				return e, nil
+
+			case key.Matches(msg, e.bindings.Editor.Left):
+				e.editor, cmd = e.editor.Update(tea.KeyMsg{Type: tea.KeyLeft})
+				return e, cmd
+
+			case key.Matches(msg, e.bindings.Editor.Right):
+				e.editor, cmd = e.editor.Update(tea.KeyMsg{Type: tea.KeyRight})
+				return e, cmd
+
+			case key.Matches(msg, e.bindings.Editor.Down):
+				e.editor.CursorDown()
+				return e, nil
+
+			case key.Matches(msg, e.bindings.Editor.Up):
+				e.editor.CursorUp()
+				return e, nil
+			}
+
+			return e, nil
+		case InsertMode:
+			switch {
+			case key.Matches(msg, e.bindings.Editor.Normal):
+				e.mode = NormalMode
+				e.editor.Cursor.SetMode(cursor.CursorStatic)
+				// Optional: move back one space on escape
+				e.editor, _ = e.editor.Update(tea.KeyMsg{Type: tea.KeyLeft})
+				return e, nil
+			}
+		}
 	}
 
+	e.editor, cmd = e.editor.Update(msg)
 	return e, cmd
 }
 

--- a/pkg/bubbletui/resultset.go
+++ b/pkg/bubbletui/resultset.go
@@ -45,14 +45,14 @@ type ResultSet struct {
 	width, height int
 	tabStyles     *tabStyles
 
-	bindings *command.TUIKeyBindings
+	bindings *command.TUIKeyMap
 
 	viewport       viewport.Model
 	tablesMetadata []table.Model
 	dump           io.Writer
 }
 
-func NewResultSet(kb *command.TUIKeyBindings) ResultSet {
+func NewResultSet(kb *command.TUIKeyMap) ResultSet {
 	var dump *os.File
 	if _, ok := os.LookupEnv("DBLAB_DEBUG"); ok {
 		var err error

--- a/pkg/bubbletui/sidebar.go.go
+++ b/pkg/bubbletui/sidebar.go.go
@@ -67,13 +67,13 @@ type SidebarViewport struct {
 	sidebarViewport viewport.Model
 	dbTree          *treeview.TuiTreeModel[string]
 
-	bindings *command.TUIKeyBindings
+	bindings *command.TUIKeyMap
 
 	activeDatabase string
 	width, height  int
 }
 
-func NewSidebarViewport(ctx context.Context, c *client.Client, kb *command.TUIKeyBindings) (SidebarViewport, error) {
+func NewSidebarViewport(ctx context.Context, c *client.Client, kb *command.TUIKeyMap) (SidebarViewport, error) {
 	svp := SidebarViewport{c: c, bindings: kb}
 
 	svp.sidebarViewport = viewport.New(0, 0)

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -41,15 +41,15 @@ type Options struct {
 	TrustServerCertificate string
 	ConnectionTimeout      string
 	// TUI keybidings.
-	TUIKeyBindings TUIKeyBindings
+	TUIKeyBindings TUIKeyMap
 }
 
 // UpdateKeybindings method updates the TUIKeyBindings field, since the keybidings configuration parted ways with the connection configuration.
-func (o *Options) UpdateKeybindings(k TUIKeyBindings) {
+func (o *Options) UpdateKeybindings(k TUIKeyMap) {
 	o.TUIKeyBindings = k
 }
 
-type TUIKeyBindings struct {
+type TUIKeyMap struct {
 	ExecuteQuery    key.Binding
 	NextTab         key.Binding
 	PrevTab         key.Binding

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -50,7 +50,6 @@ func (o *Options) UpdateKeybindings(k TUIKeyMap) {
 }
 
 type TUIKeyMap struct {
-	ExecuteQuery    key.Binding
 	NextTab         key.Binding
 	PrevTab         key.Binding
 	PageTop         key.Binding
@@ -85,10 +84,6 @@ type TUINavigationKeyMap struct {
 
 func DefaultKeyMap() TUIKeyMap {
 	return TUIKeyMap{
-		ExecuteQuery: key.NewBinding(
-			key.WithKeys("ctrl+e"),
-			key.WithHelp("ctrl+e", "execute query"),
-		),
 		NextTab: key.NewBinding(
 			key.WithKeys("tab"),
 			key.WithHelp("tab", "next tab"),

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -57,18 +57,34 @@ type TUIKeyMap struct {
 	PageBottom      key.Binding
 	EndOfLine       key.Binding
 	BeginningOfLine key.Binding
-	Navigation      TUINavigationBindgins
+	Navigation      TUINavigationKeyMap
+	Editor          EditorKeyMap
 }
 
-type TUINavigationBindgins struct {
+type EditorKeyMap struct {
+	// Normal Mode Navigation.
+	Up    key.Binding
+	Down  key.Binding
+	Left  key.Binding
+	Right key.Binding
+
+	// Mode Switching.
+	Insert key.Binding
+	Normal key.Binding
+
+	// Actions.
+	ExecuteQuery key.Binding
+}
+
+type TUINavigationKeyMap struct {
 	Up    key.Binding
 	Down  key.Binding
 	Left  key.Binding
 	Right key.Binding
 }
 
-func DefaultKeyMap() TUIKeyBindings {
-	return TUIKeyBindings{
+func DefaultKeyMap() TUIKeyMap {
+	return TUIKeyMap{
 		ExecuteQuery: key.NewBinding(
 			key.WithKeys("ctrl+e"),
 			key.WithHelp("ctrl+e", "execute query"),
@@ -97,7 +113,7 @@ func DefaultKeyMap() TUIKeyBindings {
 			key.WithKeys("$"),
 			key.WithHelp("$", "navigate all the way to the right of the table"),
 		),
-		Navigation: TUINavigationBindgins{
+		Navigation: TUINavigationKeyMap{
 			Up: key.NewBinding(
 				key.WithKeys("ctrl+k"),
 				key.WithKeys("ctrl+k", "Toggle to the panel above"),
@@ -113,6 +129,40 @@ func DefaultKeyMap() TUIKeyBindings {
 			Right: key.NewBinding(
 				key.WithKeys("ctrl+l"),
 				key.WithHelp("ctrl+l", "Toggle to the panel on the right"),
+			),
+		},
+		Editor: EditorKeyMap{
+			Up: key.NewBinding(
+				key.WithKeys("k"),
+				key.WithHelp("k", "up"),
+			),
+			Down: key.NewBinding(
+				key.WithKeys("j"),
+				key.WithHelp("j", "down"),
+			),
+			Left: key.NewBinding(
+				key.WithKeys("h"),
+				key.WithHelp("h", "left"),
+			),
+			Right: key.NewBinding(
+				key.WithKeys("l"),
+				key.WithHelp("l", "right"),
+			),
+
+			// --- Mode Switching ---
+			Insert: key.NewBinding(
+				key.WithKeys("i"),
+				key.WithHelp("i", "insert mode"),
+			),
+			Normal: key.NewBinding(
+				key.WithKeys("esc"),
+				key.WithHelp("esc", "normal mode"),
+			),
+
+			// --- Actions ---
+			ExecuteQuery: key.NewBinding(
+				key.WithKeys("ctrl+e"),
+				key.WithHelp("ctrl+e", "execute query"),
 			),
 		},
 	}

--- a/pkg/config/.dblab.yaml
+++ b/pkg/config/.dblab.yaml
@@ -72,3 +72,10 @@ keybindings:
     down: 'ctrl+j'
     left: 'ctrl+h'
     right: 'ctrl+l'
+  editor:
+    insert: 'i'
+    normal: 'esc'
+    up: 'k'
+    down: 'j'
+    left: 'h'
+    right: 'l'

--- a/pkg/config/.dblab.yaml
+++ b/pkg/config/.dblab.yaml
@@ -64,7 +64,6 @@ database:
     ssh-key-pass: "hiuwiewnc092"
 limit: 50
 keybindings:
-  execute-query: 'ctrl+e'
   next-tab: 'tab'
   prev-tab: 'shift+tab'
   navigation:
@@ -73,6 +72,7 @@ keybindings:
     left: 'ctrl+h'
     right: 'ctrl+l'
   editor:
+    execute-query: 'ctrl+e'
     insert: 'i'
     normal: 'esc'
     up: 'k'

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -81,6 +81,22 @@ type KeyBindings struct {
 	EndOfLine       string `fig:"end-of-line"   default:"$"`
 	BeginningOfLine string `fig:"beginning-of-line"   default:"0"`
 	Navigation      NavigationBindgins
+	Editor          EditorKeyMap
+}
+
+type EditorKeyMap struct {
+	// Normal Mode Navigation.
+	Up    string `fig:"up" default:"k"`
+	Down  string `fig:"down" default:"j"`
+	Left  string `fig:"left" default:"h"`
+	Right string `fig:"right" default:"l"`
+
+	// Mode Switching.
+	Insert string `fig:"insert" default:"i"`
+	Normal string `fig:"normal" default:"esc"`
+
+	// Actions.
+	ExecuteQuery string `fig:"execute-query" default:"ctrl+e"`
 }
 
 type NavigationBindgins struct {
@@ -196,11 +212,20 @@ func SetupKeyMap() (command.TUIKeyMap, error) {
 		PageBottom:      key.NewBinding(key.WithKeys(kbc.KeyBindings.PageBottom), key.WithHelp(kbc.KeyBindings.PageBottom, "go to bottom")),
 		EndOfLine:       key.NewBinding(key.WithKeys(kbc.KeyBindings.EndOfLine), key.WithHelp(kbc.KeyBindings.EndOfLine, "end of current line")),
 		BeginningOfLine: key.NewBinding(key.WithKeys(kbc.KeyBindings.BeginningOfLine), key.WithHelp(kbc.KeyBindings.BeginningOfLine, "beginning of current line")),
-		Navigation: command.TUINavigationBindgins{
+		Navigation: command.TUINavigationKeyMap{
 			Up:    key.NewBinding(key.WithKeys(kbc.KeyBindings.Navigation.Up), key.WithHelp(kbc.KeyBindings.Navigation.Up, "Toggle to the panel above")),
 			Down:  key.NewBinding(key.WithKeys(kbc.KeyBindings.Navigation.Down), key.WithHelp(kbc.KeyBindings.Navigation.Down, "Toggle to the panel below")),
 			Left:  key.NewBinding(key.WithKeys(kbc.KeyBindings.Navigation.Left), key.WithHelp(kbc.KeyBindings.Navigation.Left, "Toggle to the panel on the left")),
 			Right: key.NewBinding(key.WithKeys(kbc.KeyBindings.Navigation.Right), key.WithHelp(kbc.KeyBindings.Navigation.Right, "Toggle to the panel on the right")),
+		},
+		Editor: command.EditorKeyMap{
+			Up:           key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Up), key.WithHelp(kbc.KeyBindings.Editor.Up, "move up")),
+			Down:         key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Down), key.WithHelp(kbc.KeyBindings.Editor.Down, "move down")),
+			Left:         key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Left), key.WithHelp(kbc.KeyBindings.Editor.Left, "move left")),
+			Right:        key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Right), key.WithHelp(kbc.KeyBindings.Editor.Right, "move right")),
+			Insert:       key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Insert), key.WithHelp(kbc.KeyBindings.Editor.Insert, "insert mode")),
+			Normal:       key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Normal), key.WithHelp(kbc.KeyBindings.Editor.Normal, "normal mode")),
+			ExecuteQuery: key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.ExecuteQuery), key.WithHelp(kbc.KeyBindings.Editor.ExecuteQuery, "execute query")),
 		},
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	Limit    uint `fig:"limit" default:"100"`
 }
 
-type KeyBindingsConfig struct {
+type KeyMapConfig struct {
 	KeyBindings KeyBindings
 }
 
@@ -170,9 +170,9 @@ func Init(configName string) (command.Options, error) {
 	return opts, nil
 }
 
-func SetupKeybindings() (command.TUIKeyBindings, error) {
-	var kbc KeyBindingsConfig
-	var tkb command.TUIKeyBindings
+func SetupKeyMap() (command.TUIKeyMap, error) {
+	var kbc KeyMapConfig
+	var tkb command.TUIKeyMap
 
 	configDir, err := os.UserConfigDir()
 	if err != nil {
@@ -188,7 +188,7 @@ func SetupKeybindings() (command.TUIKeyBindings, error) {
 		return tkb, err
 	}
 
-	tkb = command.TUIKeyBindings{
+	tkb = command.TUIKeyMap{
 		ExecuteQuery:    key.NewBinding(key.WithKeys(kbc.KeyBindings.ExecuteQuery), key.WithHelp(kbc.KeyBindings.ExecuteQuery, "execute query")),
 		NextTab:         key.NewBinding(key.WithKeys(kbc.KeyBindings.NextTab), key.WithHelp(kbc.KeyBindings.NextTab, "next tab")),
 		PrevTab:         key.NewBinding(key.WithKeys(kbc.KeyBindings.PrevTab), key.WithHelp(kbc.KeyBindings.PrevTab, "previous tab")),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,7 +73,6 @@ type Database struct {
 }
 
 type KeyBindings struct {
-	ExecuteQuery    string `fig:"execute-query" default:"ctrl+e"`
 	NextTab         string `fig:"next-tab"      default:"tab"`
 	PrevTab         string `fig:"prev-tab"      default:"shift+tab"`
 	PageTop         string `fig:"page-top"      default:"g"`
@@ -205,7 +204,6 @@ func SetupKeyMap() (command.TUIKeyMap, error) {
 	}
 
 	tkb = command.TUIKeyMap{
-		ExecuteQuery:    key.NewBinding(key.WithKeys(kbc.KeyBindings.ExecuteQuery), key.WithHelp(kbc.KeyBindings.ExecuteQuery, "execute query")),
 		NextTab:         key.NewBinding(key.WithKeys(kbc.KeyBindings.NextTab), key.WithHelp(kbc.KeyBindings.NextTab, "next tab")),
 		PrevTab:         key.NewBinding(key.WithKeys(kbc.KeyBindings.PrevTab), key.WithHelp(kbc.KeyBindings.PrevTab, "previous tab")),
 		PageTop:         key.NewBinding(key.WithKeys(kbc.KeyBindings.PageTop), key.WithHelp(kbc.KeyBindings.PageTop, "go to top")),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -176,7 +176,6 @@ func TestSetupKeybindings(t *testing.T) {
 	kb, err := config.SetupKeyMap()
 	assert.NoError(t, err)
 
-	assert.Contains(t, kb.ExecuteQuery.Keys(), "ctrl+e")
 	assert.Contains(t, kb.NextTab.Keys(), "tab")
 	assert.Contains(t, kb.PrevTab.Keys(), "shift+tab")
 	assert.Contains(t, kb.Navigation.Up.Keys(), "ctrl+k")
@@ -187,4 +186,12 @@ func TestSetupKeybindings(t *testing.T) {
 	assert.Contains(t, kb.PageTop.Keys(), "g")
 	assert.Contains(t, kb.EndOfLine.Keys(), "$")
 	assert.Contains(t, kb.BeginningOfLine.Keys(), "0")
+
+	assert.Contains(t, kb.Editor.ExecuteQuery.Keys(), "ctrl+e")
+	assert.Contains(t, kb.Editor.Up.Keys(), "k")
+	assert.Contains(t, kb.Editor.Down.Keys(), "j")
+	assert.Contains(t, kb.Editor.Right.Keys(), "l")
+	assert.Contains(t, kb.Editor.Left.Keys(), "h")
+	assert.Contains(t, kb.Editor.Insert.Keys(), "i")
+	assert.Contains(t, kb.Editor.Normal.Keys(), "esc")
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -173,7 +173,7 @@ func TestInit(t *testing.T) {
 }
 
 func TestSetupKeybindings(t *testing.T) {
-	kb, err := config.SetupKeybindings()
+	kb, err := config.SetupKeyMap()
 	assert.NoError(t, err)
 
 	assert.Contains(t, kb.ExecuteQuery.Keys(), "ctrl+e")


### PR DESCRIPTION
# Vim-inspired query editor

## Description

This branch replaces the plain textarea behavior in the SQL query panel with a **Vim-inspired editor**: **normal** and **insert** modes, configurable motion keys, line-oriented commands, and query execution bound through **`keybindings.editor`** in `.dblab.yaml`. Documentation (README and MkDocs site) is updated to match, including key-binding tables and config examples.

## Motivation

The query editor previously behaved like a standard multiline field. A modal, Vim-like workflow makes it easier to move and edit SQL without leaving the keyboard, while keeping execution on a dedicated binding (default **Ctrl+E**).

## Implementation highlights

### `pkg/bubbletui/editor.go`

- Introduces **NormalMode** and **InsertMode**; the editor starts in **normal** mode when focused.
- **Insert mode:** text is entered as usual (via the bubbles `textarea`); **Escape** returns to normal mode (cursor moves one character left, similar to Vim).
- **Normal mode:** configurable **h / j / k / l** for cursor movement; **i** enters insert mode; **dd** / **yy** / **p** for delete line, yank line, paste after; **x** deletes the character under the cursor; **0** / **$** for start/end of line.
- **Execute query** is handled via **`bindings.Editor.ExecuteQuery`** (not a top-level TUI binding). Empty or whitespace-only queries do not run.
- Optional **`DBLAB_DEBUG`**: when set, incoming messages are dumped to `editor_messages.log` for debugging.

### `pkg/command/command.go`

- **`TUIKeyMap`** no longer carries a top-level **ExecuteQuery** binding; editor actions live under **`EditorKeyMap`** (including **ExecuteQuery**, **Insert**, **Normal**, and motion keys).
- **`DefaultKeyMap()`** defines defaults aligned with the Vim-style editor (e.g. **h/j/k/l**, **i**, **Esc**, **Ctrl+E** for execute).

### `pkg/config/config.go`

- **`KeyBindings`** in YAML no longer includes a top-level **`execute-query`** field; **`execute-query`** is configured under **`keybindings.editor`** alongside **`up` / `down` / `left` / `right`**, **`insert`**, and **`normal`**.
- **`SetupKeyMap()`** builds **`TUIKeyMap.Editor`** from **`kbc.KeyBindings.Editor`**, including **`ExecuteQuery`**.

## Configuration

Example `.dblab.yaml` fragment:

```yaml
keybindings:
  next-tab: 'tab'
  prev-tab: 'shift+tab'
  page-top: 'g'
  page-bottom: 'G'
  end-of-line: '$'
  beginning-of-line: '0'
  navigation:
    up: 'ctrl+k'
    down: 'ctrl+j'
    left: 'ctrl+h'
    right: 'ctrl+l'
  editor:
    up: 'k'
    down: 'j'
    left: 'h'
    right: 'l'
    insert: 'i'
    normal: 'esc'
    execute-query: 'ctrl+e'
```

Load with **`--keybindings`** or **`-k`**.

### Deprecation note (documentation)

The README documents that a **top-level** `execute-query` under `keybindings` is **deprecated**; authors should use **`keybindings.editor.execute-query`** instead. (This matches moving execution binding fully under the editor map in code and config.)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Locally, against databases running in containers

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
