### PR TITLE
fix(connection): avoid nil pointer panic on socket file stat error

### DIFF
--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -448,7 +448,7 @@ func hasValidSQLServerPrefix(rawurl string) bool {
 
 func socketFileExists(socketFile string) bool {
 	info, err := os.Stat(socketFile)
-	if os.IsNotExist(err) {
+	if err != nil {
 		return false
 	}
 

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -1038,3 +1038,15 @@ func TestParseDSN(t *testing.T) {
 		})
 	}
 }
+
+func TestSocketFileExistsStatError(t *testing.T) {
+	// A path that traverses through a regular file yields a stat error
+	// other than os.IsNotExist, leaving info nil.
+	dir := t.TempDir()
+	regularFile := fmt.Sprintf("%s/regular", dir)
+	assert.NoError(t, os.WriteFile(regularFile, []byte("x"), 0o600))
+
+	assert.NotPanics(t, func() {
+		assert.False(t, socketFileExists(fmt.Sprintf("%s/inner.sock", regularFile)))
+	})
+}


### PR DESCRIPTION
## Description

`socketFileExists` only returns early when `os.Stat` fails with an "not exists" error. For any other stat error (for example `ENOTDIR` when a path component is a regular file, or a permission error), `info` is `nil` but the code still calls `info.IsDir()`, causing a nil pointer dereference panic.

This is reachable from `BuildConnectionFromOpts` for the MySQL driver when a user passes a `--socket` path whose parent is not a directory. The fix treats any stat error as "socket does not exist".

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added `TestSocketFileExistsStatError`, which points the helper at a `.sock` path that traverses through a regular file (yielding a non-IsNotExist stat error). The test panics on the old code and passes with the fix. Verified with `go test -short -race ./pkg/connection/`, `go vet`, and `gofmt`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
