### PR TITLE
Refresh catalog on  ddl query execution

### DIFF
--- a/pkg/bubbletui/bubbletui.go
+++ b/pkg/bubbletui/bubbletui.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"io"
 	"os"
+	"strings"
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	"github.com/Digital-Shane/treeview/v2"
 	"github.com/common-nighthawk/go-figure"
 	"github.com/danvergara/dblab/pkg/client"
 	"github.com/danvergara/dblab/pkg/command"
@@ -75,13 +77,23 @@ type metadataErrMsg struct{ err error }
 // querySuccessMsg struct used to get result sets from executed queries asynchronously.
 // Sometimes, tables can be created, altered of deleted, so the this returns a refreshed list of tables.
 type querySuccessMsg struct {
-	columns []string
-	rows    [][]string
-	tables  []string
+	columns       []string
+	rows          [][]string
+	tables        []string
+	reloadCatalog bool
 }
 
 // queryErrMsg struct used to report when the query execution fails.
 type queryErrMsg struct{ err error }
+
+// updateGraphMsg struct used to refresh the database graph from executed queries asynchronously.
+// It's triggered when the user either submits a DDL (Data Definition Language) query with a drop, create, alter, etc.
+type updateGraphMsg struct {
+	tree *treeview.TuiTreeModel[*client.DBNode]
+}
+
+// queryErrMsg struct used to report when the grap update fails.
+type updateGraphErrMsg struct{ err error }
 
 type Model struct {
 	// database client.
@@ -247,6 +259,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, cmd)
 		m.sidebarViewport, cmd = m.sidebarViewport.Update(msg)
 		cmds = append(cmds, cmd)
+	case updateGraphMsg, updateGraphErrMsg:
+		m.sidebarViewport, cmd = m.sidebarViewport.Update(msg)
+		cmds = append(cmds, cmd)
 	}
 
 	switch m.focus {
@@ -341,6 +356,19 @@ func (m *Model) executeQueryCmd(query string) tea.Cmd {
 			return queryErrMsg{err}
 		}
 
-		return querySuccessMsg{columns: columns, rows: rows, tables: ts}
+		qsMsg := querySuccessMsg{columns: columns, rows: rows, tables: ts}
+
+		cleanQuery := strings.TrimSpace(query)
+		firstWord := ""
+		if parts := strings.Fields(cleanQuery); len(parts) > 0 {
+			firstWord = strings.ToLower(parts[0])
+		}
+
+		switch firstWord {
+		case "create", "drop", "alter", "truncate", "rename":
+			qsMsg.reloadCatalog = true
+		}
+
+		return qsMsg
 	}
 }

--- a/pkg/bubbletui/bubbletui.go
+++ b/pkg/bubbletui/bubbletui.go
@@ -262,6 +262,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case updateGraphMsg, updateGraphErrMsg:
 		m.sidebarViewport, cmd = m.sidebarViewport.Update(msg)
 		cmds = append(cmds, cmd)
+		m.resulstset, cmd = m.resulstset.Update(msg)
+		cmds = append(cmds, cmd)
 	}
 
 	switch m.focus {

--- a/pkg/bubbletui/resultset.go
+++ b/pkg/bubbletui/resultset.go
@@ -168,6 +168,12 @@ func (r ResultSet) Update(msg tea.Msg) (ResultSet, tea.Cmd) {
 		r.viewport.SetContent(styledError)
 		r.viewport.GotoTop()
 		return r, nil
+	case updateGraphErrMsg:
+		errorText := fmt.Sprintf("❌ FAILED TO LOAD THE CATALOG\n\n%s", msg.err.Error())
+		styledError := errorStyle.Render(errorText)
+		r.viewport.SetContent(styledError)
+		r.viewport.GotoTop()
+		return r, nil
 	case querySuccessMsg:
 		r.clearTables()
 		tableContentColumns, tableContentRows := populateTable(msg.columns, msg.rows)

--- a/pkg/bubbletui/sidebar.go
+++ b/pkg/bubbletui/sidebar.go
@@ -207,6 +207,17 @@ func (s SidebarViewport) Update(msg tea.Msg) (SidebarViewport, tea.Cmd) {
 		}
 
 		return s, cmd
+	case querySuccessMsg:
+		var cmd tea.Cmd
+		if msg.reloadCatalog {
+			cmd = s.updateGraph()
+		}
+		return s, cmd
+	case updateGraphMsg:
+		s.dbTree = msg.tree
+		return s, nil
+	case updateGraphErrMsg:
+		return s, nil
 	}
 
 	return s, cmd
@@ -223,6 +234,35 @@ func (s SidebarViewport) View() string {
 	sideViewContent = tablesListStyle.BorderForeground(listBorder).Height(s.height).Render(sideViewContent)
 
 	return sideViewContent
+}
+
+// updateGraph method refreshes the database catalog asynchronously, so it does not block the bubbletea execution.
+// If it succeeds, returns a updateGraphMsg with the a new database tree. Otherwise, it returns  updateGraphErrMsg with the error.
+func (s *SidebarViewport) updateGraph() tea.Cmd {
+	focusedID := s.dbTree.GetFocusedID()
+	return func() tea.Msg {
+		ctx := context.Background()
+		root, err := s.c.Catalog(ctx)
+		if err != nil {
+			return updateGraphErrMsg{err}
+		}
+
+		tree, err := treeview.NewTreeFromNestedData[*client.DBNode](
+			ctx,
+			[]*client.DBNode{root},
+			&DBGraphTreeBuilderProvider{},
+			treeview.WithProvider(createCyberpunkProvider()),
+		)
+		if err != nil {
+			return updateGraphErrMsg{err}
+		}
+
+		dbTree := s.newTuiTreeModel(tree, 0, s.height-2)
+		dbTree.SetFocusedID(ctx, focusedID)
+		dbTree.ExpandAll(ctx)
+
+		return updateGraphMsg{tree: dbTree}
+	}
 }
 
 func createCyberpunkProvider() *treeview.DefaultNodeProvider[*client.DBNode] {

--- a/pkg/bubbletui/sidebar.go
+++ b/pkg/bubbletui/sidebar.go
@@ -239,7 +239,6 @@ func (s SidebarViewport) View() string {
 // updateGraph method refreshes the database catalog asynchronously, so it does not block the bubbletea execution.
 // If it succeeds, returns a updateGraphMsg with the a new database tree. Otherwise, it returns  updateGraphErrMsg with the error.
 func (s *SidebarViewport) updateGraph() tea.Cmd {
-	focusedID := s.dbTree.GetFocusedID()
 	return func() tea.Msg {
 		ctx := context.Background()
 		root, err := s.c.Catalog(ctx)
@@ -258,8 +257,7 @@ func (s *SidebarViewport) updateGraph() tea.Cmd {
 		}
 
 		dbTree := s.newTuiTreeModel(tree, 0, s.height-2)
-		dbTree.SetFocusedID(ctx, focusedID)
-		dbTree.ExpandAll(ctx)
+		_, _ = dbTree.SetFocusedID(ctx, root.ID)
 
 		return updateGraphMsg{tree: dbTree}
 	}


### PR DESCRIPTION
## Refresh catalog on DDL query execution

### Summary

This PR automatically refreshes the database catalog (sidebar tree) whenever the user executes a DDL query (e.g., `CREATE`, `DROP`, `ALTER`, `TRUNCATE`, `RENAME`). Previously, the sidebar would remain stale after schema changes, requiring the user to restart the application to see updated tables and structures.

### Changes

- **Detect DDL queries**: After executing a query, the first keyword is inspected. If it matches a DDL statement (`create`, `drop`, `alter`, `truncate`, `rename`), the `querySuccessMsg` is flagged with `reloadCatalog: true`.
- **Async catalog refresh**: A new `updateGraph` method on `SidebarViewport` fetches the catalog and rebuilds the tree view asynchronously via a Bubble Tea command, so it does not block the UI.
- **New message types**: `updateGraphMsg` and `updateGraphErrMsg` are introduced to propagate the refreshed tree (or errors) through the Bubble Tea update loop.
- **Sidebar handles refresh**: The `SidebarViewport.Update` method now listens for `querySuccessMsg` to trigger a reload and for `updateGraphMsg` to swap in the new tree.
- **Cleanup**: Removed a stale `expandAll` method call from the sidebar.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Locally, against databases running on containers.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
