### PR TITLE
Add Full Support for Views Listing and Definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,16 @@ run: build
 run-pagila: build
 	DBLAB_DEBUG="" ./dblab --host localhost --user postgres --db postgres --pass 123456 --schema public --ssl disable --port 5432 --driver postgres --limit 50 -k
 
+.PHONY: run-sakila
+## run-sakila: Runs the application and connects to the sakila database
+run-sakila: build
+	DBLAB_DEBUG="" ./dblab --host localhost --user sakila --db sakila --pass p_ssW0rd --ssl disable --port 3306 --driver mysql --limit 50 -k
+
+.PHONY: run-chinook
+## run-chinook: Runs the application with a connection to the Chinook sqlite database
+run-chinook: build
+	./dblab --db chinook.db --driver sqlite
+
 .PHONY: run-ssh
 ## run-ssh: Runs the application through a ssh tunnel
 run-ssh: build

--- a/pkg/bubbletui/bubbletui.go
+++ b/pkg/bubbletui/bubbletui.go
@@ -132,6 +132,9 @@ type Model struct {
 	dump io.Writer
 }
 
+// NewModel returns a pointer to the main dblab bubbletea model.
+// It also buids the sub-models, along with styling and the app title.
+// If DBLAB_DEBUG is set, the constructor function will create a messages.log file to log bubbletui events.
 func NewModel(c *client.Client, kb *command.TUIKeyMap) (*Model, error) {
 	var dump *os.File
 	if _, ok := os.LookupEnv("DBLAB_DEBUG"); ok {

--- a/pkg/bubbletui/bubbletui.go
+++ b/pkg/bubbletui/bubbletui.go
@@ -69,6 +69,7 @@ var (
 // metadataSucessMsg struct used to retrieve a given table's metadata asynchronously.
 type metadataSuccessMsg struct {
 	metadata *client.Metadata
+	isTable  bool
 }
 
 // metadataErrMsg struct used to report error to user at the time to retrieve metadata.
@@ -252,6 +253,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			tableRef.Schema = msg.Schema
 		}
 		return m, m.runTableMetadata(tableRef)
+	case selectViewMsg:
+		viewRef := client.ViewRef{Name: msg.View}
+		switch m.c.Driver() {
+		case drivers.PostgreSQL, drivers.Postgres, drivers.PostgresSSH, drivers.Oracle:
+			viewRef.Schema = msg.Schema
+		}
+		return m, m.runViewMetadata(viewRef)
 	case executeQueryMsg:
 		return m, m.executeQueryCmd(msg.Query)
 	case metadataErrMsg, metadataSuccessMsg, queryErrMsg, querySuccessMsg:
@@ -336,7 +344,8 @@ func (m *Model) Run() error {
 }
 
 // runTableMetadata gets the given table's metadata asynchronously.
-// If the query succeeds, it returns metadataSucessMsg with the metadata, otherwise it returns metadataErrMsg with the error.
+// If the query succeeds, it returns metadataSucessMsg with the metadata,
+// otherwise it returns metadataErrMsg with the error.
 func (m *Model) runTableMetadata(table client.TableRef) tea.Cmd {
 	return func() tea.Msg {
 		metadata, err := m.c.Metadata(table)
@@ -344,7 +353,21 @@ func (m *Model) runTableMetadata(table client.TableRef) tea.Cmd {
 			return metadataErrMsg{err}
 		}
 
-		return metadataSuccessMsg{metadata}
+		return metadataSuccessMsg{metadata: metadata, isTable: true}
+	}
+}
+
+// runViewMetadata gets the given view's metadata asynchronously.
+// If the query succeeds, it returns viewMetadataSucessMsg with the metadata,
+// otherwise it returns viewMetadataErrMsg with the error.
+func (m *Model) runViewMetadata(view client.ViewRef) tea.Cmd {
+	return func() tea.Msg {
+		metadata, err := m.c.ViewMetadata(view)
+		if err != nil {
+			return metadataErrMsg{err}
+		}
+
+		return metadataSuccessMsg{metadata: metadata}
 	}
 }
 

--- a/pkg/bubbletui/resultset.go
+++ b/pkg/bubbletui/resultset.go
@@ -38,6 +38,46 @@ func newTabStyles() *tabStyles {
 	return s
 }
 
+type MetadataPanel interface {
+	tea.Model
+}
+
+type TablePanel struct {
+	table table.Model
+}
+
+func (t *TablePanel) Init() tea.Cmd { return nil }
+
+func (t *TablePanel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	updatedTable, cmd := t.table.Update(msg)
+	t.table = updatedTable
+	return t, cmd
+}
+
+func (t *TablePanel) View() tea.View {
+	return tea.NewView(t.table.View())
+}
+
+type TextPanel struct {
+	content string
+}
+
+func (t *TextPanel) Init() tea.Cmd {
+	return nil
+}
+
+func (t *TextPanel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	return t, nil
+}
+
+func (t *TextPanel) View() tea.View {
+	return tea.NewView(t.content)
+}
+
+func (t *TextPanel) SetContent(content string) {
+	t.content = content
+}
+
 type ResultSet struct {
 	focused       bool
 	tabs          []string
@@ -48,7 +88,7 @@ type ResultSet struct {
 	bindings *command.TUIKeyMap
 
 	viewport       viewport.Model
-	tablesMetadata []table.Model
+	tablesMetadata []MetadataPanel
 	dump           io.Writer
 }
 
@@ -69,7 +109,6 @@ func NewResultSet(kb *command.TUIKeyMap) ResultSet {
 	}
 
 	rs.tabStyles = newTabStyles()
-	rs.setupTable()
 
 	return rs
 }
@@ -90,12 +129,21 @@ func (r *ResultSet) SetSize(w, h int) {
 	r.viewport.SetHeight(h)
 }
 
-func (r *ResultSet) setupTable() {
-	columns := setupTable(r.height, r.width)
-	data := setupTable(r.height, r.width)
-	constraints := setupTable(r.height, r.width)
-	indexes := setupTable(r.height, r.width)
-	r.tablesMetadata = []table.Model{
+func (r *ResultSet) setupViews() {
+	viewDef := newTextPanel()
+	columns := newTablePanel(r.height, r.width)
+	r.tablesMetadata = []MetadataPanel{
+		viewDef,
+		columns,
+	}
+}
+
+func (r *ResultSet) setupTables() {
+	columns := newTablePanel(r.height, r.width)
+	data := newTablePanel(r.height, r.width)
+	constraints := newTablePanel(r.height, r.width)
+	indexes := newTablePanel(r.height, r.width)
+	r.tablesMetadata = []MetadataPanel{
 		data,
 		columns,
 		indexes,
@@ -119,18 +167,18 @@ func (r ResultSet) Update(msg tea.Msg) (ResultSet, tea.Cmd) {
 		switch {
 		case key.Matches(msg, r.bindings.NextTab):
 			r.activeTab = min(r.activeTab+1, len(r.tabs)-1)
-			r.viewport.SetContent(r.tablesMetadata[r.activeTab].View())
+			r.viewport.SetContent(r.tablesMetadata[r.activeTab].View().Content)
 			return r, nil
 		case key.Matches(msg, r.bindings.PrevTab):
 			r.activeTab = max(r.activeTab-1, 0)
-			r.viewport.SetContent(r.tablesMetadata[r.activeTab].View())
+			r.viewport.SetContent(r.tablesMetadata[r.activeTab].View().Content)
 			return r, nil
 		case key.Matches(msg, r.bindings.BeginningOfLine):
 			r.viewport.SetXOffset(0)
 			return r, nil
 		case key.Matches(msg, r.bindings.EndOfLine):
 			maxWidth := 0
-			for line := range strings.SplitSeq(r.tablesMetadata[r.activeTab].View(), "\n") {
+			for line := range strings.SplitSeq(r.tablesMetadata[r.activeTab].View().Content, "\n") {
 				w := lipgloss.Width(line)
 				if w > maxWidth {
 					maxWidth = w
@@ -160,7 +208,7 @@ func (r ResultSet) Update(msg tea.Msg) (ResultSet, tea.Cmd) {
 		cmds = append(cmds, cmd)
 
 		r.tablesMetadata[r.activeTab], cmd = r.tablesMetadata[r.activeTab].Update(msg)
-		r.viewport.SetContent(r.tablesMetadata[r.activeTab].View())
+		r.viewport.SetContent(r.tablesMetadata[r.activeTab].View().Content)
 		cmds = append(cmds, cmd)
 	case queryErrMsg:
 		errorText := fmt.Sprintf("❌ QUERY FAILED\n\n%s", msg.err.Error())
@@ -176,19 +224,25 @@ func (r ResultSet) Update(msg tea.Msg) (ResultSet, tea.Cmd) {
 		return r, nil
 	case querySuccessMsg:
 		r.clearTables()
+		r.setupTables()
+		r.tabs = []string{"Data", "Columns", "Indexes", "Constraints"}
+		r.activeTab = 0
 		tableContentColumns, tableContentRows := populateTable(msg.columns, msg.rows)
-		r.tablesMetadata[0].SetColumns(tableContentColumns)
-		r.tablesMetadata[0].SetRows(tableContentRows)
-		r.viewport.SetContent(r.tablesMetadata[0].View())
-		r.viewport.GotoTop()
+		if tablePanel, ok := r.tablesMetadata[0].(*TablePanel); ok {
+			tablePanel.table.SetColumns(tableContentColumns)
+			tablePanel.table.SetRows(tableContentRows)
+			r.tablesMetadata[0] = tablePanel
+			r.viewport.SetContent(r.tablesMetadata[0].View().Content)
+			r.viewport.GotoTop()
+		}
 		return r, nil
 	case metadataSuccessMsg:
-		r.updateTableMetadataOnChange(msg.metadata)
-		r.viewport.SetContent(r.tablesMetadata[r.activeTab].View())
+		r.updateMetadataOnChange(msg.metadata, msg.isTable)
+		r.viewport.SetContent(r.tablesMetadata[r.activeTab].View().Content)
 		r.viewport.GotoTop()
 		return r, nil
 	case metadataErrMsg:
-		errorText := fmt.Sprintf("❌ failed to get table metadata\n\n%s", msg.err.Error())
+		errorText := fmt.Sprintf("❌ failed to get metadata\n\n%s", msg.err.Error())
 		styledError := errorStyle.Render(errorText)
 		r.viewport.SetContent(styledError)
 		r.viewport.GotoTop()
@@ -260,34 +314,66 @@ func (r ResultSet) View() tea.View {
 
 func (r *ResultSet) clearTables() {
 	for i := range r.tablesMetadata {
-		r.tablesMetadata[i] = setupTable(r.height, r.width)
+		r.tablesMetadata[i] = newTablePanel(r.height, r.width)
 	}
 }
 
-// updateTableMetadataOnChange method is used to print the table metadata retrieved asynchronously.
-func (r *ResultSet) updateTableMetadataOnChange(metadata *client.Metadata) {
+// updateMetadataOnChange method is used to print the table metadata retrieved asynchronously.
+func (r *ResultSet) updateMetadataOnChange(metadata *client.Metadata, isTable bool) {
 	if metadata != nil {
 		r.clearTables()
+		if isTable {
+			r.setupTables()
 
-		// table data.
-		tableContentColumns, tableContentRows := populateTable(metadata.TableContent.Columns, metadata.TableContent.Rows)
-		r.tablesMetadata[0].SetColumns(tableContentColumns)
-		r.tablesMetadata[0].SetRows(tableContentRows)
+			r.tabs = []string{"Data", "Columns", "Indexes", "Constraints"}
+			r.activeTab = 0
 
-		// table columns.
-		tableStructureColumns, tableStructureRows := populateTable(metadata.Structure.Columns, metadata.Structure.Rows)
-		r.tablesMetadata[1].SetColumns(tableStructureColumns)
-		r.tablesMetadata[1].SetRows(tableStructureRows)
+			// table data.
+			tableContentColumns, tableContentRows := populateTable(metadata.TableContent.Columns, metadata.TableContent.Rows)
+			if tablePanel, ok := r.tablesMetadata[0].(*TablePanel); ok {
+				tablePanel.table.SetColumns(tableContentColumns)
+				tablePanel.table.SetRows(tableContentRows)
+			}
 
-		// table indexes.
-		tableIndexColumns, tableIndexRows := populateTable(metadata.Indexes.Columns, metadata.Indexes.Rows)
-		r.tablesMetadata[2].SetColumns(tableIndexColumns)
-		r.tablesMetadata[2].SetRows(tableIndexRows)
+			// table columns.
+			tableStructureColumns, tableStructureRows := populateTable(metadata.Structure.Columns, metadata.Structure.Rows)
+			if tablePanel, ok := r.tablesMetadata[1].(*TablePanel); ok {
+				tablePanel.table.SetColumns(tableStructureColumns)
+				tablePanel.table.SetRows(tableStructureRows)
+			}
 
-		// table constraints.
-		tableConstraintsColumns, tableConstraintsRows := populateTable(metadata.Constraints.Columns, metadata.Constraints.Rows)
-		r.tablesMetadata[3].SetColumns(tableConstraintsColumns)
-		r.tablesMetadata[3].SetRows(tableConstraintsRows)
+			// table indexes.
+			tableIndexColumns, tableIndexRows := populateTable(metadata.Indexes.Columns, metadata.Indexes.Rows)
+			if tablePanel, ok := r.tablesMetadata[2].(*TablePanel); ok {
+				tablePanel.table.SetColumns(tableIndexColumns)
+				tablePanel.table.SetRows(tableIndexRows)
+			}
+
+			// table constraints.
+			tableConstraintsColumns, tableConstraintsRows := populateTable(metadata.Constraints.Columns, metadata.Constraints.Rows)
+			if tablePanel, ok := r.tablesMetadata[3].(*TablePanel); ok {
+				tablePanel.table.SetColumns(tableConstraintsColumns)
+				tablePanel.table.SetRows(tableConstraintsRows)
+			}
+		} else {
+			r.setupViews()
+			r.tabs = []string{"View Def", "Data"}
+			r.activeTab = 0
+
+			if textPanel, ok := r.tablesMetadata[0].(*TextPanel); ok {
+				if len(metadata.ViewDef.Rows) > 0 {
+					if len(metadata.ViewDef.Columns[0]) > 0 {
+						textPanel.SetContent(metadata.ViewDef.Rows[0][0])
+					}
+				}
+			}
+
+			viewContentColumns, viewContentRows := populateTable(metadata.TableContent.Columns, metadata.TableContent.Rows)
+			if tablePanel, ok := r.tablesMetadata[1].(*TablePanel); ok {
+				tablePanel.table.SetColumns(viewContentColumns)
+				tablePanel.table.SetRows(viewContentRows)
+			}
+		}
 	}
 }
 
@@ -302,8 +388,7 @@ func tabBorderWithBottom(left, middle, right string) lipgloss.Border {
 	return border
 }
 
-// prepare method sets up the client defaults, such as the tables, the editor, the initial queries to show the either the databases or tables the user has access to and the styles.
-func setupTable(height, width int) table.Model {
+func newTablePanel(height, width int) *TablePanel {
 	t := table.New(
 		table.WithFocused(true),
 		table.WithWidth(width-2),
@@ -326,13 +411,19 @@ func setupTable(height, width int) table.Model {
 
 	t.SetStyles(s)
 
-	return t
+	return &TablePanel{
+		table: t,
+	}
+}
+
+func newTextPanel() *TextPanel {
+	return &TextPanel{}
 }
 
 func populateTable(headers []string, data [][]string) ([]table.Column, []table.Row) {
 	colWidths := make([]int, len(headers))
-
 	var rows []table.Row
+
 	for _, stringRow := range data {
 		row := make(table.Row, len(stringRow))
 

--- a/pkg/bubbletui/sidebar.go
+++ b/pkg/bubbletui/sidebar.go
@@ -28,6 +28,11 @@ type selectTableMsg struct {
 	Table  string
 }
 
+type selectViewMsg struct {
+	Schema string
+	View   string
+}
+
 type SidebarViewport struct {
 	c        *client.Client
 	bindings *command.TUIKeyMap
@@ -140,7 +145,7 @@ func (s SidebarViewport) Update(msg tea.Msg) (SidebarViewport, tea.Cmd) {
 				switch (*selectedNode.Data()).Type {
 				case "table":
 					selectTableCmd := func() tea.Msg {
-						stm := selectTableMsg{Table: selectedNode.Name()}
+						stm := selectTableMsg{Table: (*selectedNode.Data()).EntityName}
 						switch s.c.Driver() {
 						case drivers.PostgreSQL, drivers.Postgres, drivers.PostgresSSH, drivers.Oracle:
 							stm.Schema = (*selectedNode.Data()).ParentName
@@ -149,6 +154,18 @@ func (s SidebarViewport) Update(msg tea.Msg) (SidebarViewport, tea.Cmd) {
 					}
 
 					return s, selectTableCmd
+				case "view":
+					selectViewCmd := func() tea.Msg {
+						stm := selectViewMsg{View: (*selectedNode.Data()).EntityName}
+						switch s.c.Driver() {
+
+						case drivers.PostgreSQL, drivers.Postgres, drivers.PostgresSSH, drivers.Oracle:
+							stm.Schema = (*selectedNode.Data()).ParentName
+						}
+
+						return stm
+					}
+					return s, selectViewCmd
 				}
 			}
 		}

--- a/pkg/bubbletui/sidebar.go
+++ b/pkg/bubbletui/sidebar.go
@@ -268,11 +268,13 @@ func createCyberpunkProvider() *treeview.DefaultNodeProvider[*client.DBNode] {
 	databaseIconRule := treeview.WithIconRule(dbObjectHasType("database"), "⛃")
 	schemaIconRule := treeview.WithIconRule(dbObjectHasType("schema"), "📁")
 	tableIconRule := treeview.WithIconRule(dbObjectHasType("table"), "📋")
+	viewIconRule := treeview.WithIconRule(dbObjectHasType("view"), "📑")
 
 	return treeview.NewDefaultNodeProvider[*client.DBNode](
 		databaseIconRule,
 		schemaIconRule,
 		tableIconRule,
+		viewIconRule,
 		treeview.WithStyleRule(
 			func(n *treeview.Node[*client.DBNode]) bool { return true },
 			lipgloss.NewStyle().

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -23,9 +23,17 @@ type TableRef struct {
 	Name   string
 }
 
+type ViewRef struct {
+	Schema string
+	Name   string
+}
+
 type DBNode struct {
-	ID         string
-	Name       string
+	ID string
+	// Name is used to display on the TUI.
+	Name string
+	// EntityName is used to run queries.
+	EntityName string
 	Type       string
 	ParentID   string
 	ParentName string
@@ -42,6 +50,7 @@ type databaseQuerier interface {
 	Constraints(table TableRef) (string, []any, error)
 	Indexes(table TableRef) (string, []any, error)
 	Catalog(context.Context) (*DBNode, error)
+	GetViewDefinition(view ViewRef) (string, []any, error)
 }
 
 // Client is used to store the pool of db connection.
@@ -151,6 +160,11 @@ func (c *Client) Query(q string, args ...any) ([][]string, []string, error) {
 		return nil, nil, err
 	}
 
+	colTypes, err := rows.ColumnTypes()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	for rows.Next() {
 		// cols is an []any of all of the column results.
 		cols, err := rows.SliceScan()
@@ -161,13 +175,26 @@ func (c *Client) Query(q string, args ...any) ([][]string, []string, error) {
 		// Convert []any into []string.
 		s := make([]string, len(cols))
 		for i, v := range cols {
-			switch v.(type) {
-			case string, rune, []byte:
-				s[i] = fmt.Sprintf("%s", v)
+			switch val := v.(type) {
+			case []byte:
+				// Isolate []byte and check the database type
+				dbType := colTypes[i].DatabaseTypeName()
+
+				// Check for both MySQL BLOBs and Postgres BYTEA
+				switch dbType {
+				case "BLOB", "TINYBLOB", "MEDIUMBLOB", "LONGBLOB", "BYTEA":
+					// Safely represent the BLOB without printing raw binary
+					s[i] = fmt.Sprintf("[BLOB - %d bytes]", len(val))
+				default:
+					// It's a normal string/text type returned as []byte, safe to convert
+					s[i] = string(val)
+				}
+			case string, rune:
+				s[i] = fmt.Sprintf("%s", val)
 			case nil:
-				s[i] = fmt.Sprint(v)
+				s[i] = fmt.Sprint(val)
 			default:
-				s[i] = fmt.Sprintf("%v", v)
+				s[i] = fmt.Sprintf("%v", val)
 			}
 		}
 
@@ -197,7 +224,12 @@ type Metadata struct {
 	Structure    Table
 	Constraints  Table
 	Indexes      Table
+	ViewDef      Table
 	TotalPages   int
+}
+
+type ViewMetadata struct {
+	ViewDef Table
 }
 
 // Metadata returns the most relevant data from a given table.
@@ -244,6 +276,30 @@ func (c *Client) Metadata(table TableRef) (*Metadata, error) {
 	return &m, nil
 }
 
+func (c *Client) ViewMetadata(view ViewRef) (*Metadata, error) {
+	vdRows, vdColumns, err := c.viewDefintion(view)
+	if err != nil {
+		return nil, err
+	}
+	vcRows, vcColumns, err := c.viewContent(view)
+	if err != nil {
+		return nil, err
+	}
+
+	vm := Metadata{
+		ViewDef: Table{
+			Rows:    vdRows,
+			Columns: vdColumns,
+		},
+		TableContent: Table{
+			Rows:    vcRows,
+			Columns: vcColumns,
+		},
+	}
+
+	return &vm, nil
+}
+
 // TableContent returns all the rows of a table.
 func (c *Client) tableContent(table TableRef) ([][]string, []string, error) {
 	var query string
@@ -267,7 +323,8 @@ func (c *Client) tableContent(table TableRef) ([][]string, []string, error) {
 		)
 	case drivers.SQLServer:
 		query = fmt.Sprintf(
-			"SELECT * FROM %s ORDER BY (SELECT NULL) OFFSET %d ROWS FETCH NEXT %d ROWS ONLY",
+			"SELECT * FROM %s.%s ORDER BY (SELECT NULL) OFFSET %d ROWS FETCH NEXT %d ROWS ONLY",
+			table.Schema,
 			table.Name,
 			c.paginationManager.Offset(),
 			c.paginationManager.Limit(),
@@ -281,6 +338,44 @@ func (c *Client) tableContent(table TableRef) ([][]string, []string, error) {
 		)
 	}
 
+	return c.Query(query)
+}
+
+func (c *Client) viewContent(view ViewRef) ([][]string, []string, error) {
+	var query string
+	switch c.driver {
+	case drivers.Postgres, drivers.PostgreSQL, drivers.PostgresSSH:
+		query = fmt.Sprintf(
+			"SELECT * FROM %s.%s LIMIT %d OFFSET %d;",
+			view.Schema,
+			view.Name,
+			c.paginationManager.Limit(),
+			c.paginationManager.Offset(),
+		)
+	case drivers.Oracle:
+		query = fmt.Sprintf(
+			"SELECT * FROM %s.%s OFFSET %d ROWS FETCH NEXT %d ROWS ONLY",
+			strings.ToUpper(view.Schema),
+			strings.ToUpper(view.Name),
+			c.paginationManager.Offset(),
+			c.paginationManager.Limit(),
+		)
+	case drivers.SQLServer:
+		query = fmt.Sprintf(
+			"SELECT * FROM %s.%s ORDER BY (SELECT NULL) OFFSET %d ROWS FETCH NEXT %d ROWS ONLY",
+			view.Schema,
+			view.Name,
+			c.paginationManager.Offset(),
+			c.paginationManager.Limit(),
+		)
+	default:
+		query = fmt.Sprintf(
+			"SELECT * FROM %s LIMIT %d OFFSET %d;",
+			view.Name,
+			c.paginationManager.Limit(),
+			c.paginationManager.Offset(),
+		)
+	}
 	return c.Query(query)
 }
 
@@ -322,4 +417,13 @@ func (c *Client) indexes(table TableRef) ([][]string, []string, error) {
 
 func (c *Client) Catalog(ctx context.Context) (*DBNode, error) {
 	return c.databaseQuerier.Catalog(ctx)
+}
+
+func (c *Client) viewDefintion(view ViewRef) ([][]string, []string, error) {
+	query, args, err := c.databaseQuerier.GetViewDefinition(view)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return c.Query(query, args...)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -228,10 +228,6 @@ type Metadata struct {
 	TotalPages   int
 }
 
-type ViewMetadata struct {
-	ViewDef Table
-}
-
 // Metadata returns the most relevant data from a given table.
 func (c *Client) Metadata(table TableRef) (*Metadata, error) {
 	tcRows, tcColumns, err := c.tableContent(table)
@@ -276,6 +272,8 @@ func (c *Client) Metadata(table TableRef) (*Metadata, error) {
 	return &m, nil
 }
 
+// ViewMetadata returns the most relevant data from a given view.
+// It returns the view sql definition.
 func (c *Client) ViewMetadata(view ViewRef) (*Metadata, error) {
 	vdRows, vdColumns, err := c.viewDefintion(view)
 	if err != nil {
@@ -300,7 +298,7 @@ func (c *Client) ViewMetadata(view ViewRef) (*Metadata, error) {
 	return &vm, nil
 }
 
-// TableContent returns all the rows of a table.
+// tableContent returns a portion of the data of a given table scoped by the offset and limit.
 func (c *Client) tableContent(table TableRef) ([][]string, []string, error) {
 	var query string
 
@@ -341,6 +339,7 @@ func (c *Client) tableContent(table TableRef) ([][]string, []string, error) {
 	return c.Query(query)
 }
 
+// viewContent returns a portion of the data of a given view scoped by the offset and limit.
 func (c *Client) viewContent(view ViewRef) ([][]string, []string, error) {
 	var query string
 	switch c.driver {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -90,7 +90,7 @@ func New(opts command.Options) (*Client, error) {
 	case drivers.Oracle:
 		c.databaseQuerier = newOracle(c.dbName, c.schema, c.db)
 	case drivers.SQLServer:
-		c.databaseQuerier = newMSSQL(c.dbName, c.db)
+		c.databaseQuerier = newMSSQL(c.dbName, c.schema, c.db)
 	default:
 		return nil, fmt.Errorf("%s driver not supported", c.driver)
 	}

--- a/pkg/client/mssql.go
+++ b/pkg/client/mssql.go
@@ -109,6 +109,19 @@ func (m *mssql) Indexes(table TableRef) (string, []interface{}, error) {
 	return query, args, nil
 }
 
+// Catalog returns a the pointer to a DBNode instance,
+// which is the root of the current SQL Server database graph.
+// It starts with the database itself,
+// then the schemas and the correspondent lists of tables and views.
+// SQL Server topography:
+//
+//					 [Database]
+//				       |
+//				       v
+//			     [Schemas]
+//			      /     \
+//			     v       v
+//	 		 [Tables] 	[Views]
 func (m *mssql) Catalog(ctx context.Context) (*DBNode, error) {
 	rootID := fmt.Sprintf("db:%s", m.dbName)
 	root := &DBNode{ID: rootID, Name: m.dbName, Type: "database"}
@@ -160,6 +173,7 @@ func (m *mssql) Catalog(ctx context.Context) (*DBNode, error) {
 	return root, nil
 }
 
+// GetViewDefinition method returns the SQL definition of a given view.
 func (m *mssql) GetViewDefinition(view ViewRef) (string, []any, error) {
 	psql := sq.StatementBuilder.PlaceholderFormat(sq.Question)
 	query, args, err := psql.
@@ -174,6 +188,7 @@ func (m *mssql) GetViewDefinition(view ViewRef) (string, []any, error) {
 	return query, args, nil
 }
 
+// fetchSchemas method lists all the schemas of the current database.
 func (m *mssql) fetchSchemas(ctx context.Context, parentID string) ([]*DBNode, error) {
 	query, args, err := sq.Select("s.name").
 		From("sys.schemas AS s").
@@ -214,6 +229,7 @@ func (m *mssql) fetchSchemas(ctx context.Context, parentID string) ([]*DBNode, e
 	return schemas, nil
 }
 
+// fetchTables method returns a list of tables filtered by schema.
 func (m *mssql) fetchTables(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
 	query, args, err := sq.Select("TABLE_NAME").
 		From("INFORMATION_SCHEMA.TABLES").
@@ -254,6 +270,7 @@ func (m *mssql) fetchTables(ctx context.Context, parentName, parentID string) ([
 	return tables, nil
 }
 
+// fetchViews method returns a list of views filtered by schema.
 func (m *mssql) fetchViews(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
 	query, args, err := sq.Select("TABLE_NAME").
 		From("INFORMATION_SCHEMA.VIEWS").

--- a/pkg/client/mssql.go
+++ b/pkg/client/mssql.go
@@ -12,16 +12,19 @@ import (
 type mssql struct {
 	db     *sqlx.DB
 	dbName string
+	schema string
 }
 
 var _ databaseQuerier = (*mssql)(nil)
 
 // returns a pointer to a mysql.
-func newMSSQL(dbName string, db *sqlx.DB) *mssql {
+func newMSSQL(dbName, schema string, db *sqlx.DB) *mssql {
 	m := mssql{
 		dbName: dbName,
 		db:     db,
+		schema: schema,
 	}
+
 	return &m
 }
 
@@ -120,7 +123,28 @@ func (m *mssql) Catalog(ctx context.Context) (*DBNode, error) {
 		var err error
 		switch current.Type {
 		case "database":
-			children, err = m.fetchTables(ctx, current.Name, current.ID)
+			if m.schema != "" {
+				children = append(children, &DBNode{
+					ID:       fmt.Sprintf("%s.s:%s", rootID, m.schema),
+					Name:     m.schema,
+					Type:     "schema",
+					ParentID: rootID,
+				})
+			} else {
+				children, err = m.fetchSchemas(ctx, current.Name)
+			}
+		case "schema":
+			tables, err := m.fetchTables(ctx, current.Name, current.ID)
+			if err != nil {
+				return nil, err
+			}
+			children = append(children, tables...)
+
+			views, err := m.fetchViews(ctx, current.Name, current.ID)
+			if err != nil {
+				return nil, err
+			}
+			children = append(children, views...)
 		}
 		if err != nil {
 			return nil, err
@@ -135,10 +159,57 @@ func (m *mssql) Catalog(ctx context.Context) (*DBNode, error) {
 	return root, nil
 }
 
-func (m *mssql) fetchTables(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
-	query := "SHOW TABLES;"
+func (m *mssql) fetchSchemas(ctx context.Context, parentID string) ([]*DBNode, error) {
+	query, args, err := sq.Select("s.name").
+		From("sys.schemas AS s").
+		Join("sys.database_principals p ON s.principal_id = p.principal_id").
+		OrderBy("s.name").
+		PlaceholderFormat(sq.AtP).
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
 
-	rows, err := m.db.Query(query)
+	rows, err := m.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var schemas []*DBNode
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		schemas = append(schemas, &DBNode{
+
+			ID:       fmt.Sprintf("%s.s:%s", parentID, name),
+			Name:     name,
+			Type:     "schema",
+			ParentID: parentID,
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return schemas, nil
+}
+
+func (m *mssql) fetchTables(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
+	query, args, err := sq.Select("TABLE_NAME").
+		From("INFORMATION_SCHEMA.TABLES").
+		Where(sq.Eq{
+			"TABLE_SCHEMA": parentName,
+			"TABLE_TYPE":   "BASE TABLE",
+		}).PlaceholderFormat(sq.AtP).ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := m.db.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -164,4 +235,44 @@ func (m *mssql) fetchTables(ctx context.Context, parentName, parentID string) ([
 	}
 
 	return tables, nil
+}
+
+func (m *mssql) fetchViews(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
+	query, args, err := sq.Select("TABLE_NAME").
+		From("INFORMATION_SCHEMA.VIEWS").
+		Where(sq.Eq{
+			"TABLE_SCHEMA": parentName,
+		}).
+		PlaceholderFormat(sq.AtP).
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := m.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	views := make([]*DBNode, 0)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		views = append(views, &DBNode{
+			ID:         fmt.Sprintf("%s.v:%s", parentID, name),
+			Name:       name + " - " + "v",
+			Type:       "view",
+			ParentName: parentName,
+			ParentID:   parentID,
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return views, nil
 }

--- a/pkg/client/mssql.go
+++ b/pkg/client/mssql.go
@@ -125,10 +125,11 @@ func (m *mssql) Catalog(ctx context.Context) (*DBNode, error) {
 		case "database":
 			if m.schema != "" {
 				children = append(children, &DBNode{
-					ID:       fmt.Sprintf("%s.s:%s", rootID, m.schema),
-					Name:     m.schema,
-					Type:     "schema",
-					ParentID: rootID,
+					ID:         fmt.Sprintf("%s.s:%s", rootID, m.schema),
+					Name:       m.schema,
+					EntityName: m.schema,
+					Type:       "schema",
+					ParentID:   rootID,
 				})
 			} else {
 				children, err = m.fetchSchemas(ctx, current.Name)
@@ -159,6 +160,20 @@ func (m *mssql) Catalog(ctx context.Context) (*DBNode, error) {
 	return root, nil
 }
 
+func (m *mssql) GetViewDefinition(view ViewRef) (string, []any, error) {
+	psql := sq.StatementBuilder.PlaceholderFormat(sq.Question)
+	query, args, err := psql.
+		Select().
+		Column(sq.Expr("OBJECT_DEFINITION(OBJECT_ID(?)) AS view_definition", fmt.Sprintf("%s.%s", view.Schema, view.Name))).
+		ToSql()
+
+	if err != nil {
+		return "", nil, err
+	}
+
+	return query, args, nil
+}
+
 func (m *mssql) fetchSchemas(ctx context.Context, parentID string) ([]*DBNode, error) {
 	query, args, err := sq.Select("s.name").
 		From("sys.schemas AS s").
@@ -184,10 +199,11 @@ func (m *mssql) fetchSchemas(ctx context.Context, parentID string) ([]*DBNode, e
 		}
 		schemas = append(schemas, &DBNode{
 
-			ID:       fmt.Sprintf("%s.s:%s", parentID, name),
-			Name:     name,
-			Type:     "schema",
-			ParentID: parentID,
+			ID:         fmt.Sprintf("%s.s:%s", parentID, name),
+			Name:       name,
+			EntityName: name,
+			Type:       "schema",
+			ParentID:   parentID,
 		})
 	}
 
@@ -223,7 +239,8 @@ func (m *mssql) fetchTables(ctx context.Context, parentName, parentID string) ([
 
 		tables = append(tables, &DBNode{
 			ID:         fmt.Sprintf("%s.t:%s", parentID, name),
-			Name:       name,
+			Name:       name + " - " + "t",
+			EntityName: name,
 			Type:       "table",
 			ParentName: parentName,
 			ParentID:   parentID,
@@ -264,6 +281,7 @@ func (m *mssql) fetchViews(ctx context.Context, parentName, parentID string) ([]
 		views = append(views, &DBNode{
 			ID:         fmt.Sprintf("%s.v:%s", parentID, name),
 			Name:       name + " - " + "v",
+			EntityName: name,
 			Type:       "view",
 			ParentName: parentName,
 			ParentID:   parentID,

--- a/pkg/client/mysql.go
+++ b/pkg/client/mysql.go
@@ -57,6 +57,15 @@ func (m *mysql) Indexes(table TableRef) (string, []any, error) {
 	return query, nil, nil
 }
 
+// Catalog returns a the pointer to a DBNode instance,
+// which is the root of the current MySQL database graph.
+// It starts with the database itself and a list of tables a views.
+// MySQL topography:
+//
+//			     [Database]
+//			      /     \
+//			     v       v
+//	 			[Tables] 	[Views]
 func (m *mysql) Catalog(ctx context.Context) (*DBNode, error) {
 	rootID := fmt.Sprintf("db:%s", m.dbName)
 	root := &DBNode{ID: rootID, Name: m.dbName, Type: "database"}
@@ -96,6 +105,7 @@ func (m *mysql) Catalog(ctx context.Context) (*DBNode, error) {
 	return root, nil
 }
 
+// GetViewDefinition method returns the SQL definition of a given view.
 func (m *mysql) GetViewDefinition(view ViewRef) (string, []any, error) {
 	psql := sq.StatementBuilder.PlaceholderFormat(sq.Question)
 
@@ -115,6 +125,7 @@ func (m *mysql) GetViewDefinition(view ViewRef) (string, []any, error) {
 	return query, args, nil
 }
 
+// fetchTables method lists all the tables of the current database.
 func (m *mysql) fetchTables(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
 	query := "SHOW TABLES;"
 
@@ -147,6 +158,7 @@ func (m *mysql) fetchTables(ctx context.Context, parentName, parentID string) ([
 	return tables, nil
 }
 
+// fetchViews method lists all the views of the current database.
 func (m *mysql) fetchViews(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
 	query, args, err := sq.
 		Select("TABLE_NAME AS view_name").

--- a/pkg/client/mysql.go
+++ b/pkg/client/mysql.go
@@ -71,7 +71,17 @@ func (m *mysql) Catalog(ctx context.Context) (*DBNode, error) {
 		var err error
 		switch current.Type {
 		case "database":
-			children, err = m.fetchTables(ctx, current.Name, current.ID)
+			tables, err := m.fetchTables(ctx, current.Name, current.ID)
+			if err != nil {
+				return nil, err
+			}
+			children = append(children, tables...)
+
+			views, err := m.fetchViews(ctx, current.Name, current.ID)
+			if err != nil {
+				return nil, err
+			}
+			children = append(children, views...)
 		}
 		if err != nil {
 			return nil, err
@@ -84,6 +94,25 @@ func (m *mysql) Catalog(ctx context.Context) (*DBNode, error) {
 	}
 
 	return root, nil
+}
+
+func (m *mysql) GetViewDefinition(view ViewRef) (string, []any, error) {
+	psql := sq.StatementBuilder.PlaceholderFormat(sq.Question)
+
+	query, args, err := psql.
+		Select("VIEW_DEFINITION AS view_definition").
+		From("information_schema.VIEWS").
+		Where(sq.Eq{
+			"TABLE_SCHEMA": m.dbName,
+			"TABLE_NAME":   view.Name,
+		}).
+		ToSql()
+
+	if err != nil {
+		return "", nil, err
+	}
+
+	return query, args, nil
 }
 
 func (m *mysql) fetchTables(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
@@ -103,7 +132,8 @@ func (m *mysql) fetchTables(ctx context.Context, parentName, parentID string) ([
 
 		tables = append(tables, &DBNode{
 			ID:         fmt.Sprintf("%s.t:%s", parentID, name),
-			Name:       name,
+			Name:       name + " - " + "t",
+			EntityName: name,
 			Type:       "table",
 			ParentName: parentName,
 			ParentID:   parentID,
@@ -115,4 +145,46 @@ func (m *mysql) fetchTables(ctx context.Context, parentName, parentID string) ([
 	}
 
 	return tables, nil
+}
+
+func (m *mysql) fetchViews(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
+	query, args, err := sq.
+		Select("TABLE_NAME AS view_name").
+		From("information_schema.VIEWS").
+		Where(sq.Eq{
+			"TABLE_SCHEMA": m.dbName,
+		}).
+		PlaceholderFormat(sq.Question).
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := m.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	views := make([]*DBNode, 0)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		views = append(views, &DBNode{
+			ID:         fmt.Sprintf("%s.v:%s", parentName, name),
+			Name:       name + " - " + "v",
+			EntityName: name,
+			Type:       "view",
+			ParentName: parentName,
+			ParentID:   parentID,
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return views, nil
 }

--- a/pkg/client/oracle.go
+++ b/pkg/client/oracle.go
@@ -156,6 +156,24 @@ func (o *oracle) Catalog(ctx context.Context) (*DBNode, error) {
 	return root, nil
 }
 
+func (o *oracle) GetViewDefinition(view ViewRef) (string, []any, error) {
+	psql := sq.StatementBuilder.PlaceholderFormat(sq.Question)
+	query, args, err := psql.
+		Select("TEXT AS view_definition").
+		From("ALL_VIEWS").
+		Where(sq.Eq{
+			"OWNER":     strings.ToUpper(view.Schema),
+			"VIEW_NAME": strings.ToUpper(view.Name),
+		}).
+		ToSql()
+
+	if err != nil {
+		return "", nil, err
+	}
+
+	return query, args, nil
+}
+
 func (o *oracle) fetchSchemas(ctx context.Context, parentID string) ([]*DBNode, error) {
 	query := `
 		SELECT DISTINCT owner AS schema_name
@@ -216,6 +234,7 @@ func (o *oracle) fetchTables(ctx context.Context, parentName, parentID string) (
 		tables = append(tables, &DBNode{
 			ID:         fmt.Sprintf("%s.t:%s", parentID, name),
 			Name:       name + " - " + "t",
+			EntityName: name,
 			Type:       "table",
 			ParentName: parentName,
 			ParentID:   parentID,
@@ -254,6 +273,7 @@ func (o *oracle) fetchViews(ctx context.Context, parentName, parentID string) ([
 		views = append(views, &DBNode{
 			ID:         fmt.Sprintf("%s.v:%s", parentID, name),
 			Name:       name + " - " + "v",
+			EntityName: name,
 			Type:       "view",
 			ParentName: parentName,
 			ParentID:   parentID,

--- a/pkg/client/oracle.go
+++ b/pkg/client/oracle.go
@@ -131,7 +131,17 @@ func (o *oracle) Catalog(ctx context.Context) (*DBNode, error) {
 				children, err = o.fetchSchemas(ctx, current.Name)
 			}
 		case "schema":
-			children, err = o.fetchTables(ctx, current.Name, current.ID)
+			tables, err := o.fetchTables(ctx, current.Name, current.ID)
+			if err != nil {
+				return nil, err
+			}
+			children = append(children, tables...)
+
+			views, err := o.fetchViews(ctx, current.Name, current.ID)
+			if err != nil {
+				return nil, err
+			}
+			children = append(children, views...)
 		}
 		if err != nil {
 			return nil, err

--- a/pkg/client/oracle.go
+++ b/pkg/client/oracle.go
@@ -107,6 +107,19 @@ func (o *oracle) Indexes(table TableRef) (string, []interface{}, error) {
 	return sql, args, nil
 }
 
+// Catalog returns a the pointer to a DBNode instance,
+// which is the root of the current Oracle database graph.
+// It starts with the database itself,
+// then the schemas and the correspondent lists of tables and views.
+// Oracle topography:
+//
+//					 [Database]
+//				       |
+//				       v
+//			     [Schemas]
+//			      /     \
+//			     v       v
+//	 		 [Tables] 	[Views]
 func (o *oracle) Catalog(ctx context.Context) (*DBNode, error) {
 	rootID := fmt.Sprintf("db:%s", o.dbName)
 	root := &DBNode{ID: rootID, Name: o.dbName, Type: "database"}
@@ -156,6 +169,7 @@ func (o *oracle) Catalog(ctx context.Context) (*DBNode, error) {
 	return root, nil
 }
 
+// GetViewDefinition method returns the SQL definition of a given view.
 func (o *oracle) GetViewDefinition(view ViewRef) (string, []any, error) {
 	psql := sq.StatementBuilder.PlaceholderFormat(sq.Question)
 	query, args, err := psql.
@@ -174,6 +188,7 @@ func (o *oracle) GetViewDefinition(view ViewRef) (string, []any, error) {
 	return query, args, nil
 }
 
+// fetchSchemas method lists all the schemas of the current database.
 func (o *oracle) fetchSchemas(ctx context.Context, parentID string) ([]*DBNode, error) {
 	query := `
 		SELECT DISTINCT owner AS schema_name
@@ -208,18 +223,19 @@ func (o *oracle) fetchSchemas(ctx context.Context, parentID string) ([]*DBNode, 
 	return schemas, nil
 }
 
+// fetchTables method returns a list of tables filtered by schema.
 func (o *oracle) fetchTables(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
-	query := sq.Select("TABLE_NAME").
+	query, args, err := sq.Select("TABLE_NAME").
 		From("ALL_TABLES").
 		Where(sq.Eq{"OWNER": strings.ToUpper(parentName)}).
-		OrderBy("TABLE_NAME ASC")
-
-	sql, args, err := query.PlaceholderFormat(sq.Colon).ToSql()
+		OrderBy("TABLE_NAME ASC").
+		PlaceholderFormat(sq.Colon).
+		ToSql()
 	if err != nil {
 		return nil, err
 	}
 
-	rows, err := o.db.Query(sql, args...)
+	rows, err := o.db.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -248,17 +264,19 @@ func (o *oracle) fetchTables(ctx context.Context, parentName, parentID string) (
 	return tables, nil
 }
 
+// fetchViews method returns a list of views filtered by schema.
 func (o *oracle) fetchViews(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
-	query := sq.Select("VIEW_NAME").
+	query, args, err := sq.Select("VIEW_NAME").
 		From("ALL_VIEWS").
 		Where(sq.Eq{"OWNER": strings.ToUpper(parentName)}).
-		OrderBy("VIEW_NAME ASC")
-	sql, args, err := query.PlaceholderFormat(sq.Colon).ToSql()
+		OrderBy("VIEW_NAME ASC").
+		PlaceholderFormat(sq.Colon).
+		ToSql()
 	if err != nil {
 		return nil, err
 	}
 
-	rows, err := o.db.Query(sql, args...)
+	rows, err := o.db.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/oracle.go
+++ b/pkg/client/oracle.go
@@ -187,10 +187,6 @@ func (o *oracle) fetchTables(ctx context.Context, parentName, parentID string) (
 		OrderBy("TABLE_NAME ASC")
 
 	sql, args, err := query.PlaceholderFormat(sq.Colon).ToSql()
-
-	if err != nil {
-		return nil, err
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +205,7 @@ func (o *oracle) fetchTables(ctx context.Context, parentName, parentID string) (
 		}
 		tables = append(tables, &DBNode{
 			ID:         fmt.Sprintf("%s.t:%s", parentID, name),
-			Name:       name,
+			Name:       name + " - " + "t",
 			Type:       "table",
 			ParentName: parentName,
 			ParentID:   parentID,
@@ -221,4 +217,42 @@ func (o *oracle) fetchTables(ctx context.Context, parentName, parentID string) (
 	}
 
 	return tables, nil
+}
+
+func (o *oracle) fetchViews(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
+	query := sq.Select("VIEW_NAME").
+		From("ALL_VIEWS").
+		Where(sq.Eq{"OWNER": strings.ToUpper(parentName)}).
+		OrderBy("VIEW_NAME ASC")
+	sql, args, err := query.PlaceholderFormat(sq.Colon).ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := o.db.Query(sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	views := make([]*DBNode, 0)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		views = append(views, &DBNode{
+			ID:         fmt.Sprintf("%s.v:%s", parentID, name),
+			Name:       name + " - " + "v",
+			Type:       "view",
+			ParentName: parentName,
+			ParentID:   parentID,
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return views, nil
 }

--- a/pkg/client/postgres.go
+++ b/pkg/client/postgres.go
@@ -125,10 +125,11 @@ func (p *postgres) Catalog(ctx context.Context) (*DBNode, error) {
 		case "database":
 			if p.schema != "" {
 				children = append(children, &DBNode{
-					ID:       fmt.Sprintf("%s.s:%s", rootID, p.schema),
-					Name:     p.schema,
-					Type:     "schema",
-					ParentID: rootID,
+					ID:         fmt.Sprintf("%s.s:%s", rootID, p.schema),
+					Name:       p.schema,
+					EntityName: p.schema,
+					Type:       "schema",
+					ParentID:   rootID,
 				})
 			} else {
 				children, err = p.fetchSchemas(ctx, current.Name)
@@ -159,6 +160,19 @@ func (p *postgres) Catalog(ctx context.Context) (*DBNode, error) {
 	return root, nil
 }
 
+func (p *postgres) GetViewDefinition(view ViewRef) (string, []any, error) {
+	psql := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
+	query, args, err := psql.
+		Select().
+		Column(sq.Expr("pg_get_viewdef(?::text::regclass, true) AS view_definition", fmt.Sprintf("%s.%s", view.Schema, view.Name))).
+		ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+
+	return query, args, nil
+}
+
 func (p *postgres) fetchSchemas(ctx context.Context, parentID string) ([]*DBNode, error) {
 	query, args, err := sq.Select("schema_name").
 		From("information_schema.schemata").
@@ -185,10 +199,11 @@ func (p *postgres) fetchSchemas(ctx context.Context, parentID string) ([]*DBNode
 		}
 		schemas = append(schemas, &DBNode{
 
-			ID:       fmt.Sprintf("%s.s:%s", parentID, name),
-			Name:     name,
-			Type:     "schema",
-			ParentID: parentID,
+			ID:         fmt.Sprintf("%s.s:%s", parentID, name),
+			Name:       name,
+			EntityName: name,
+			Type:       "schema",
+			ParentID:   parentID,
 		})
 	}
 
@@ -225,6 +240,7 @@ func (p *postgres) fetchTables(ctx context.Context, parentName, parentID string)
 		tables = append(tables, &DBNode{
 			ID:         fmt.Sprintf("%s.t:%s", parentID, name),
 			Name:       name + " - " + "t",
+			EntityName: name,
 			Type:       "table",
 			ParentName: parentName,
 			ParentID:   parentID,
@@ -269,6 +285,7 @@ func (p *postgres) fetchViews(ctx context.Context, parentName, parentID string) 
 		views = append(views, &DBNode{
 			ID:         fmt.Sprintf("%s.v:%s", parentID, name),
 			Name:       name + " - " + "v",
+			EntityName: name,
 			Type:       "view",
 			ParentName: parentName,
 			ParentID:   parentID,

--- a/pkg/client/postgres.go
+++ b/pkg/client/postgres.go
@@ -119,7 +119,7 @@ func (p *postgres) Catalog(ctx context.Context) (*DBNode, error) {
 		current := queue[0]
 		queue = queue[1:]
 
-		var children []*DBNode
+		children := make([]*DBNode, 0)
 		var err error
 		switch current.Type {
 		case "database":
@@ -134,7 +134,17 @@ func (p *postgres) Catalog(ctx context.Context) (*DBNode, error) {
 				children, err = p.fetchSchemas(ctx, current.Name)
 			}
 		case "schema":
-			children, err = p.fetchTables(ctx, current.Name, current.ID)
+			tables, err := p.fetchTables(ctx, current.Name, current.ID)
+			if err != nil {
+				return nil, err
+			}
+			children = append(children, tables...)
+
+			views, err := p.fetchViews(ctx, current.Name, current.ID)
+			if err != nil {
+				return nil, err
+			}
+			children = append(children, views...)
 		}
 		if err != nil {
 			return nil, err
@@ -214,7 +224,7 @@ func (p *postgres) fetchTables(ctx context.Context, parentName, parentID string)
 		}
 		tables = append(tables, &DBNode{
 			ID:         fmt.Sprintf("%s.t:%s", parentID, name),
-			Name:       name,
+			Name:       name + " - " + "t",
 			Type:       "table",
 			ParentName: parentName,
 			ParentID:   parentID,
@@ -226,4 +236,49 @@ func (p *postgres) fetchTables(ctx context.Context, parentName, parentID string)
 	}
 
 	return tables, nil
+}
+
+func (p *postgres) fetchViews(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
+	// 'v' is View, 'm' is Materialized View.
+	query, args, err := sq.Select("c.relname AS view_name").
+		From("pg_class c").
+		Join("pg_namespace n ON n.oid = c.relnamespace").
+		Where(sq.Eq{
+			"n.nspname": parentName,
+			"c.relkind": []string{"v", "m"},
+		}).
+		OrderBy("c.relname ASC").
+		PlaceholderFormat(sq.Dollar).
+		ToSql()
+
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := p.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	views := make([]*DBNode, 0)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		views = append(views, &DBNode{
+			ID:         fmt.Sprintf("%s.v:%s", parentID, name),
+			Name:       name + " - " + "v",
+			Type:       "view",
+			ParentName: parentName,
+			ParentID:   parentID,
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return views, nil
 }

--- a/pkg/client/postgres.go
+++ b/pkg/client/postgres.go
@@ -250,7 +250,6 @@ func (p *postgres) fetchViews(ctx context.Context, parentName, parentID string) 
 		OrderBy("c.relname ASC").
 		PlaceholderFormat(sq.Dollar).
 		ToSql()
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/postgres.go
+++ b/pkg/client/postgres.go
@@ -110,6 +110,19 @@ func (p *postgres) Indexes(table TableRef) (string, []any, error) {
 	return sql, args, err
 }
 
+// Catalog returns a the pointer to a DBNode instance,
+// which is the root of the current PostgreSQL database graph.
+// It starts with the database itself,
+// then the schemas and the correspondent lists of tables and views.
+// PostgreSQL topography:
+//
+//					 [Database]
+//				       |
+//				       v
+//			     [Schemas]
+//			      /     \
+//			     v       v
+//	 		 [Tables] 	[Views]
 func (p *postgres) Catalog(ctx context.Context) (*DBNode, error) {
 	rootID := fmt.Sprintf("db:%s", p.dbName)
 	root := &DBNode{ID: rootID, Name: p.dbName, Type: "database"}
@@ -160,6 +173,7 @@ func (p *postgres) Catalog(ctx context.Context) (*DBNode, error) {
 	return root, nil
 }
 
+// GetViewDefinition method returns the SQL definition of a given view.
 func (p *postgres) GetViewDefinition(view ViewRef) (string, []any, error) {
 	psql := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 	query, args, err := psql.
@@ -173,6 +187,7 @@ func (p *postgres) GetViewDefinition(view ViewRef) (string, []any, error) {
 	return query, args, nil
 }
 
+// fetchSchemas method lists all the schemas of the current database.
 func (p *postgres) fetchSchemas(ctx context.Context, parentID string) ([]*DBNode, error) {
 	query, args, err := sq.Select("schema_name").
 		From("information_schema.schemata").
@@ -214,6 +229,7 @@ func (p *postgres) fetchSchemas(ctx context.Context, parentID string) ([]*DBNode
 	return schemas, nil
 }
 
+// fetchTables method returns a list of tables filtered by schema.
 func (p *postgres) fetchTables(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
 	query, args, err := sq.Select("table_name").
 		From("information_schema.tables").
@@ -254,6 +270,7 @@ func (p *postgres) fetchTables(ctx context.Context, parentName, parentID string)
 	return tables, nil
 }
 
+// fetchViews method returns a list of views filtered by schema.
 func (p *postgres) fetchViews(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
 	// 'v' is View, 'm' is Materialized View.
 	query, args, err := sq.Select("c.relname AS view_name").

--- a/pkg/client/sqlite.go
+++ b/pkg/client/sqlite.go
@@ -61,6 +61,15 @@ func (s *sqlite) Indexes(table TableRef) (string, []interface{}, error) {
 	return query, nil, nil
 }
 
+// Catalog returns a the pointer to a DBNode instance,
+// which is the root of the current SQLite database graph.
+// It starts with the database itself and a list of tables a views.
+// SQLite topography:
+//
+//			     [Database]
+//			      /     \
+//			     v       v
+//	 			[Tables] 	[Views]
 func (s *sqlite) Catalog(ctx context.Context) (*DBNode, error) {
 	rootID := fmt.Sprintf("db:%s", s.dbName)
 	root := &DBNode{ID: rootID, Name: s.dbName, Type: "database"}
@@ -100,6 +109,7 @@ func (s *sqlite) Catalog(ctx context.Context) (*DBNode, error) {
 	return root, nil
 }
 
+// GetViewDefinition method returns the SQL definition of a given view.
 func (s *sqlite) GetViewDefinition(view ViewRef) (string, []any, error) {
 	psql := sq.StatementBuilder.PlaceholderFormat(sq.Question)
 	query, args, err := psql.
@@ -117,6 +127,7 @@ func (s *sqlite) GetViewDefinition(view ViewRef) (string, []any, error) {
 	return query, args, nil
 }
 
+// fetchTables method lists all the tables of the current database.
 func (s *sqlite) fetchTables(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
 	query := `
 		SELECT
@@ -157,6 +168,7 @@ func (s *sqlite) fetchTables(ctx context.Context, parentName, parentID string) (
 	return tables, nil
 }
 
+// fetchViews method lists all the views of the current database.
 func (s *sqlite) fetchViews(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
 	query, args, err := sq.
 		Select("name AS view_name").

--- a/pkg/client/sqlite.go
+++ b/pkg/client/sqlite.go
@@ -75,7 +75,17 @@ func (s *sqlite) Catalog(ctx context.Context) (*DBNode, error) {
 		var err error
 		switch current.Type {
 		case "database":
-			children, err = s.fetchTables(ctx, current.Name, current.ID)
+			tables, err := s.fetchTables(ctx, current.Name, current.ID)
+			if err != nil {
+				return nil, err
+			}
+			children = append(children, tables...)
+
+			views, err := s.fetchViews(ctx, current.Name, current.ID)
+			if err != nil {
+				return nil, err
+			}
+			children = append(children, views...)
 		}
 		if err != nil {
 			return nil, err
@@ -88,6 +98,23 @@ func (s *sqlite) Catalog(ctx context.Context) (*DBNode, error) {
 	}
 
 	return root, nil
+}
+
+func (s *sqlite) GetViewDefinition(view ViewRef) (string, []any, error) {
+	psql := sq.StatementBuilder.PlaceholderFormat(sq.Question)
+	query, args, err := psql.
+		Select("sql AS view_definition").
+		From("sqlite_master").
+		Where(sq.Eq{
+			"type": "view",
+			"name": view.Name,
+		}).
+		ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+
+	return query, args, nil
 }
 
 func (s *sqlite) fetchTables(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
@@ -115,7 +142,8 @@ func (s *sqlite) fetchTables(ctx context.Context, parentName, parentID string) (
 
 		tables = append(tables, &DBNode{
 			ID:         fmt.Sprintf("%s.t:%s", parentID, name),
-			Name:       name,
+			Name:       name + " - " + "t",
+			EntityName: name,
 			Type:       "table",
 			ParentName: parentName,
 			ParentID:   parentID,
@@ -127,4 +155,47 @@ func (s *sqlite) fetchTables(ctx context.Context, parentName, parentID string) (
 	}
 
 	return tables, nil
+}
+
+func (s *sqlite) fetchViews(ctx context.Context, parentName, parentID string) ([]*DBNode, error) {
+	query, args, err := sq.
+		Select("name AS view_name").
+		From("sqlite_master").
+		Where(sq.Eq{
+			"type": "view",
+		}).
+		OrderBy("name").
+		PlaceholderFormat(sq.Question).
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	views := make([]*DBNode, 0)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		views = append(views, &DBNode{
+			ID:         fmt.Sprintf("%s.v:%s", parentID, name),
+			Name:       name + " - " + "v",
+			EntityName: name,
+			Type:       "view",
+			ParentName: parentName,
+			ParentID:   parentID,
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return views, nil
 }


### PR DESCRIPTION
# Add Full Support for Views Listing and Definitions

## Description

This PR adds comprehensive support for listing database views and displaying their definitions across all supported database drivers (PostgreSQL, MySQL, SQLite, Oracle, and SQL Server).

Previously, dblab only displayed tables in the sidebar catalog. With this change, views are now listed alongside tables (visually distinguished with a `v` suffix) and selecting a view shows its definition and column data in the result panel.

<img width="1913" height="965" alt="Screenshot From 2026-06-07 12-26-53" src="https://github.com/user-attachments/assets/cc2bd9d4-0c49-4afa-a103-10f4c2e0a384" />


## Changes

### Core Client (`pkg/client/`)

- **New `ViewRef` struct** — mirrors `TableRef` for referencing views with schema-qualified names.
- **New `EntityName` field on `DBNode`** — separates the display name (with type suffix) from the actual entity name used in queries.
- **New `databaseQuerier` method `GetViewDefinition`** — each driver implements this to retrieve the DDL/definition of a view.
- **New `ViewMetadata` method on `Client`** — fetches both the view definition and its content (rows).
- **New `viewContent` method** — queries the view data with pagination support across all drivers.
- **Improved `[]byte` handling in `Query`** — properly distinguishes BLOB/BYTEA columns from text columns returned as `[]byte`, preventing raw binary output.

### Driver Implementations

- **PostgreSQL** (`postgres.go`): Queries `pg_class` for views/materialized views (`relkind IN ('v','m')`). Uses `pg_get_viewdef()` for definitions.
- **MySQL** (`mysql.go`): Queries `information_schema.VIEWS`. Uses `SHOW CREATE VIEW` for definitions.
- **SQLite** (`sqlite.go`): Queries `sqlite_master WHERE type='view'`. Retrieves the `sql` column for definitions.
- **Oracle** (`oracle.go`): Queries `ALL_VIEWS` filtered by owner/schema. Retrieves the `TEXT` column for definitions.
- **SQL Server** (`mssql.go`): Queries `sys.views` joined with `sys.schemas`. Uses `OBJECT_DEFINITION()` for view DDL. Also adds schema handling that was previously missing.

### TUI (`pkg/bubbletui/`)

- **New `selectViewMsg`** — message type for view selection events in the sidebar.
- **New `MetadataPanel` interface** with `TablePanel` and `TextPanel` implementations — allows the result set to display either tabular data or plain text (for view definitions).
- **Updated `ResultSet`** — dynamically switches between table-mode tabs (`Data`, `Columns`, `Indexes`, `Constraints`) and view-mode tabs (`Definition`, `Columns`) depending on selection.
- **View emoji indicator** in the sidebar to distinguish views from tables.

## Supported Databases

| Database   | List Views | View Definition | View Content |
|------------|:----------:|:---------------:|:------------:|
| PostgreSQL | Yes        | Yes             | Yes          |
| MySQL      | Yes        | Yes             | Yes          |
| SQLite     | Yes        | Yes             | Yes          |
| Oracle     | Yes        | Yes             | Yes          |
| SQL Server | Yes        | Yes             | Yes          |


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Locally, against containers running the Pagila, Sakila and Chinook databases.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
