### PR TITLE
docs: add a narrated walkthrough to the home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,12 @@ multiple platforms. dblab was created as an attempt to build a very simple and p
 application to work with local or remote PostgreSQL/MySQL/SQLite3/Oracle/SQL Server databases.
   
 
+<div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;max-width:100%;margin:1.5rem 0;border-radius:10px;border:1px solid rgba(128,128,128,0.2);box-shadow:0 4px 20px rgba(0,0,0,0.15);">
+  <iframe src="https://bisque.cloud/p/github/danvergara-dblab" title="dblab — narrated walkthrough" loading="lazy"
+    style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;"
+    allow="autoplay; fullscreen; encrypted-media" allowfullscreen></iframe>
+</div>
+
 ## Features
 
   * Cross-platform support for macOS/Linux/Windows (32/64-bit)  


### PR DESCRIPTION
## Description

Adds a short (~2 min) narrated walkthrough embedded near the top of the docs home page — a quick "what is dblab + the keyboard-driven tour": connect, browse the tables tree, run a query, read results, all without the mouse. A fast orientation for first-time visitors.

It's a single responsive, lazy-loaded `<iframe>` embedding a Bisque-hosted presentation. No scripts, no dependencies, no build/config changes — one file changed (`docs/index.md`), six lines added. `md_in_html` is already enabled, so the raw HTML block renders as-is.

Not tied to an existing issue.

## Type of change

- [x] This change requires a documentation update (docs-only — adds the embed)

## How Has This Been Tested?

- Verified the page renders with the embed in place (MkDocs Material, indigo theme).
- Confirmed the presentation URL is public (loads without sign-in).
- Re-checked every command and keybinding narrated against the current docs (home, quickstart, navigation, config file).

## Checklist:

- [x] My code follows the style guidelines of this project (docs-only; Conventional Commit title)
- [x] I have performed a self-review of my own change
- [x] I have made corresponding changes to the documentation (this *is* the docs change)
- [x] I have checked my change and corrected any misspellings

Unit-test items are N/A — docs-only, no code paths touched. Happy to adjust placement/wording or close if it's not a fit.

Preview of the embedded presentation: https://bisque.cloud/p/github/danvergara-dblab
