### PR TITLE
Fix: prevent query execution if editor is empty

### DIFF
--- a/pkg/bubbletui/editor.go
+++ b/pkg/bubbletui/editor.go
@@ -90,6 +90,9 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 			editorContent := e.editor.Value()
 
 			queriesToRun := prepareQueriesForExecution(editorContent)
+			if len(queriesToRun) == 0 {
+				return e, nil
+			}
 
 			fireQueryCmd := func() tea.Msg {
 				return executeQueryMsg{queriesToRun: queriesToRun}


### PR DESCRIPTION
# prevent query execution if editor is empty

## Description

Currently if you try execution with empty editor the app exit with panic.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
