### PR TITLE
Feat: Execute query at cursor only

### DIFF
--- a/pkg/bubbletui/editor.go
+++ b/pkg/bubbletui/editor.go
@@ -101,6 +101,21 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 			return e, fireQueryCmd
 		}
 
+		if key.Matches(msg, e.bindings.Editor.ExecuteSingleQuery) {
+			value := e.editor.Value()
+
+			if len(value) == 0 {
+				return e, nil
+			}
+
+			query := queryAtCursor(value, e.editor.Line(), e.editor.Column())
+			queriesToRun := prepareQueriesForExecution(query)
+			fireQueryCmd := func() tea.Msg {
+				return executeQueryMsg{queriesToRun: queriesToRun}
+			}
+			return e, fireQueryCmd
+		}
+
 		switch e.mode {
 		case NormalMode:
 			char := msg.String()
@@ -201,6 +216,47 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 
 func (e Editor) View() tea.View {
 	return tea.NewView(e.editor.View())
+}
+
+func queryAtCursor(content string, row, col int) string {
+	lines := strings.Split(content, "\n")
+	if row < 0 || row >= len(lines) {
+		return strings.TrimSpace(content)
+	}
+
+	if col < 0 {
+		col = 0
+	} else if col > len(lines[row]) {
+		col = len(lines[row])
+	}
+
+	cursorOffset := 0
+	for i := 0; i < row; i++ {
+		cursorOffset += len(lines[i]) + 1
+	}
+	cursorOffset += col
+
+	start := 0
+	end := len(content)
+	for i := 0; i < cursorOffset && i < len(content); i++ {
+		if content[i] == ';' {
+			start = i + 1
+		}
+	}
+
+	for i := cursorOffset; i < len(content); i++ {
+		if content[i] == ';' {
+			end = i
+			break
+		}
+	}
+
+	query := strings.TrimSpace(content[start:end])
+	if query == "" {
+		return strings.TrimSpace(content)
+	}
+
+	return query
 }
 
 func (e *Editor) yankCurrentLine() {

--- a/pkg/bubbletui/editor.go
+++ b/pkg/bubbletui/editor.go
@@ -109,6 +109,9 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 			}
 
 			query := queryAtCursor(value, e.editor.Line())
+			if len(query) == 0 {
+				return e, nil
+			}
 			queriesToRun := prepareQueriesForExecution(query)
 			fireQueryCmd := func() tea.Msg {
 				return executeQueryMsg{queriesToRun: queriesToRun}

--- a/pkg/bubbletui/editor.go
+++ b/pkg/bubbletui/editor.go
@@ -108,7 +108,7 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 				return e, nil
 			}
 
-			query := queryAtCursor(value, e.editor.Line(), e.editor.Column())
+			query := queryAtCursor(value, e.editor.Line())
 			queriesToRun := prepareQueriesForExecution(query)
 			fireQueryCmd := func() tea.Msg {
 				return executeQueryMsg{queriesToRun: queriesToRun}
@@ -218,45 +218,14 @@ func (e Editor) View() tea.View {
 	return tea.NewView(e.editor.View())
 }
 
-func queryAtCursor(content string, row, col int) string {
+// queryAtCursor returns the text of the line the cursor is currently on.
+func queryAtCursor(content string, currentIndex int) string {
 	lines := strings.Split(content, "\n")
-	if row < 0 || row >= len(lines) {
-		return strings.TrimSpace(content)
+	if currentIndex >= 0 && currentIndex < len(lines) {
+		return lines[currentIndex]
 	}
 
-	if col < 0 {
-		col = 0
-	} else if col > len(lines[row]) {
-		col = len(lines[row])
-	}
-
-	cursorOffset := 0
-	for i := 0; i < row; i++ {
-		cursorOffset += len(lines[i]) + 1
-	}
-	cursorOffset += col
-
-	start := 0
-	end := len(content)
-	for i := 0; i < cursorOffset && i < len(content); i++ {
-		if content[i] == ';' {
-			start = i + 1
-		}
-	}
-
-	for i := cursorOffset; i < len(content); i++ {
-		if content[i] == ';' {
-			end = i
-			break
-		}
-	}
-
-	query := strings.TrimSpace(content[start:end])
-	if query == "" {
-		return strings.TrimSpace(content)
-	}
-
-	return query
+	return ""
 }
 
 func (e *Editor) yankCurrentLine() {

--- a/pkg/bubbletui/editor_test.go
+++ b/pkg/bubbletui/editor_test.go
@@ -1,0 +1,14 @@
+package bubbletui
+
+import "testing"
+
+func TestQueryAtCursor(t *testing.T) {
+	content := "SELECT 1;\nSELECT 2;\nSELECT 3;"
+
+	got := queryAtCursor(content, 1, 9)
+	want := "SELECT 2;"
+
+	if got != want {
+		t.Fatalf("queryAtCursor() = %q, want %q", got, want)
+	}
+}

--- a/pkg/bubbletui/editor_test.go
+++ b/pkg/bubbletui/editor_test.go
@@ -1,6 +1,10 @@
 package bubbletui
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestQueryAtCursor(t *testing.T) {
 	content := "SELECT 1;\nSELECT 2;\nSELECT 3;"
@@ -8,22 +12,19 @@ func TestQueryAtCursor(t *testing.T) {
 	tests := []struct {
 		name string
 		row  int
-		col  int
 		want string
 	}{
-		{name: "first query at start", row: 0, col: 0, want: "SELECT 1"},
-		{name: "second query in middle", row: 1, col: 4, want: "SELECT 2"},
-		{name: "second query on semicolon", row: 1, col: 8, want: "SELECT 2"},
-		{name: "third query at semicolon", row: 2, col: 8, want: "SELECT 3"},
-		{name: "third query after end of line", row: 2, col: 9, want: content},
+		{name: "first query at start", row: 0, want: "SELECT 1;"},
+		{name: "second query in middle", row: 1, want: "SELECT 2;"},
+		{name: "second query on semicolon", row: 1, want: "SELECT 2;"},
+		{name: "third query at semicolon", row: 2, want: "SELECT 3;"},
+		{name: "third query after end of line", row: 3, want: ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := queryAtCursor(content, tt.row, tt.col)
-			if got != tt.want {
-				t.Fatalf("queryAtCursor(%d, %d) = %q, want %q", tt.row, tt.col, got, tt.want)
-			}
+			got := queryAtCursor(content, tt.row)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/bubbletui/editor_test.go
+++ b/pkg/bubbletui/editor_test.go
@@ -5,10 +5,25 @@ import "testing"
 func TestQueryAtCursor(t *testing.T) {
 	content := "SELECT 1;\nSELECT 2;\nSELECT 3;"
 
-	got := queryAtCursor(content, 1, 9)
-	want := "SELECT 2;"
+	tests := []struct {
+		name string
+		row  int
+		col  int
+		want string
+	}{
+		{name: "first query at start", row: 0, col: 0, want: "SELECT 1"},
+		{name: "second query in middle", row: 1, col: 4, want: "SELECT 2"},
+		{name: "second query on semicolon", row: 1, col: 8, want: "SELECT 2"},
+		{name: "third query at semicolon", row: 2, col: 8, want: "SELECT 3"},
+		{name: "third query after end of line", row: 2, col: 9, want: content},
+	}
 
-	if got != want {
-		t.Fatalf("queryAtCursor() = %q, want %q", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := queryAtCursor(content, tt.row, tt.col)
+			if got != tt.want {
+				t.Fatalf("queryAtCursor(%d, %d) = %q, want %q", tt.row, tt.col, got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -66,7 +66,8 @@ type EditorKeyMap struct {
 	Normal key.Binding
 
 	// Actions.
-	ExecuteQuery key.Binding
+	ExecuteQuery       key.Binding
+	ExecuteSingleQuery key.Binding
 }
 
 type TUINavigationKeyMap struct {
@@ -152,6 +153,11 @@ func DefaultKeyMap() *TUIKeyMap {
 			ExecuteQuery: key.NewBinding(
 				key.WithKeys("ctrl+e"),
 				key.WithHelp("ctrl+e", "execute query"),
+			),
+
+			ExecuteSingleQuery: key.NewBinding(
+				key.WithKeys("ctrl+r"),
+				key.WithHelp("ctrl+r", "execute single query"),
 			),
 		},
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -98,7 +98,8 @@ type EditorKeyMap struct {
 	Normal string `fig:"normal" default:"esc"`
 
 	// Actions.
-	ExecuteQuery string `fig:"execute-query" default:"ctrl+e"`
+	ExecuteQuery       string `fig:"execute-query" default:"ctrl+e"`
+	ExecuteSingleQuery string `fig:"execute-single-query" default:"ctrl+r"`
 }
 
 type NavigationBindgins struct {
@@ -221,13 +222,14 @@ func SetupKeyMap() (*command.TUIKeyMap, error) {
 			Right: key.NewBinding(key.WithKeys(kbc.KeyBindings.Navigation.Right), key.WithHelp(kbc.KeyBindings.Navigation.Right, "Toggle to the panel on the right")),
 		},
 		Editor: command.EditorKeyMap{
-			Up:           key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Up), key.WithHelp(kbc.KeyBindings.Editor.Up, "move up")),
-			Down:         key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Down), key.WithHelp(kbc.KeyBindings.Editor.Down, "move down")),
-			Left:         key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Left), key.WithHelp(kbc.KeyBindings.Editor.Left, "move left")),
-			Right:        key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Right), key.WithHelp(kbc.KeyBindings.Editor.Right, "move right")),
-			Insert:       key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Insert), key.WithHelp(kbc.KeyBindings.Editor.Insert, "insert mode")),
-			Normal:       key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Normal), key.WithHelp(kbc.KeyBindings.Editor.Normal, "normal mode")),
-			ExecuteQuery: key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.ExecuteQuery), key.WithHelp(kbc.KeyBindings.Editor.ExecuteQuery, "execute query")),
+			Up:                 key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Up), key.WithHelp(kbc.KeyBindings.Editor.Up, "move up")),
+			Down:               key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Down), key.WithHelp(kbc.KeyBindings.Editor.Down, "move down")),
+			Left:               key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Left), key.WithHelp(kbc.KeyBindings.Editor.Left, "move left")),
+			Right:              key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Right), key.WithHelp(kbc.KeyBindings.Editor.Right, "move right")),
+			Insert:             key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Insert), key.WithHelp(kbc.KeyBindings.Editor.Insert, "insert mode")),
+			Normal:             key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Normal), key.WithHelp(kbc.KeyBindings.Editor.Normal, "normal mode")),
+			ExecuteQuery:       key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.ExecuteQuery), key.WithHelp(kbc.KeyBindings.Editor.ExecuteQuery, "execute query")),
+			ExecuteSingleQuery: key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.ExecuteSingleQuery), key.WithHelp(kbc.KeyBindings.Editor.ExecuteSingleQuery, "execute single query")),
 		},
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -193,6 +193,7 @@ func TestSetupKeybindings(t *testing.T) {
 	assert.Contains(t, kb.BeginningOfLine.Keys(), "0")
 
 	assert.Contains(t, kb.Editor.ExecuteQuery.Keys(), "ctrl+e")
+	assert.Contains(t, kb.Editor.ExecuteSingleQuery.Keys(), "ctrl+r")
 	assert.Contains(t, kb.Editor.Up.Keys(), "k")
 	assert.Contains(t, kb.Editor.Down.Keys(), "j")
 	assert.Contains(t, kb.Editor.Right.Keys(), "l")


### PR DESCRIPTION
# Execute query at cursor only

## Description

Execute query at cursor with key binding.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Manual and we added a test for function that determines the query to execute

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
