### PR TITLE
Add help modal

### DIFF
--- a/.dblab.yaml
+++ b/.dblab.yaml
@@ -76,6 +76,8 @@ keybindings:
   prev-tab: 'shift+tab'
   end-of-line: '$'
   beginning-of-line: '0'
+  help: '?'
+  quit: 'ctrl+c'
   navigation:
     up: 'ctrl+k'
     down: 'ctrl+j'

--- a/pkg/bubbletui/bubbletui.go
+++ b/pkg/bubbletui/bubbletui.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 
+	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -44,6 +45,7 @@ const (
 	focusList
 	focusTable
 	focusHistory
+	focusHelp
 )
 
 var (
@@ -109,6 +111,7 @@ type Model struct {
 	sidebarViewport SidebarViewport
 	resulstset      ResultSet
 	queryHistory    *HistoryModel
+	help            help.Model
 
 	// Manages the focus on the app.
 	focus focusState
@@ -128,7 +131,7 @@ type Model struct {
 	editorWidth           int
 
 	// Key Bindings.
-	bindings *command.TUIKeyMap
+	keys *command.TUIKeyMap
 
 	// constant text on the client.
 	footer        string
@@ -160,13 +163,20 @@ func NewModel(c *client.Client, kb *command.TUIKeyMap) (*Model, error) {
 
 	dblabTitle := figure.NewFigure("dblab", "", true).String()
 
+	h := help.New()
+	h.ShowAll = true
+	h.Styles.FullKey = lipgloss.NewStyle().Foreground(cyberGreen).Bold(true)
+	h.Styles.FullDesc = lipgloss.NewStyle().Foreground(whiteText)
+	h.Styles.FullSeparator = lipgloss.NewStyle().Foreground(mutedGreen)
+
 	m := &Model{
 		focus:           focusEditor,
 		c:               c,
-		bindings:        kb,
+		keys:            kb,
 		editor:          NewEditor(kb),
 		sidebarViewport: svp,
 		resulstset:      NewResultSet(kb),
+		help:            h,
 		footer:          footerStyle.Render("\n  (Press Ctrl-C to exit. Keybindings are configurable, please see the documentation for more information.)"),
 		renderedTitle:   dblabTitle,
 		titleHeight:     lipgloss.Height(dblabTitle),
@@ -209,6 +219,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.resultSetHeight = availableHeight - m.editorHeight - 4
 		m.resultSetWidth = m.rightWidth - 4
 
+		m.help.SetWidth(msg.Width)
+
 		m.editor.SetHeight(m.editorHeight)
 		m.editor.SetWidth(m.editorWidth)
 
@@ -220,12 +232,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyPressMsg:
 		switch msg.String() {
-		case "ctrl+c":
-			if m.cancelQuery != nil {
-				m.cancelQuery()
-				m.cancelQuery = nil
-			} else if msg.String() == "ctrl+c" {
-				return m, tea.Quit
+		case "esc":
+			return m, func() tea.Msg {
+				return backToNormalMsg{}
 			}
 		case "f8":
 			m.focus = focusHistory
@@ -234,7 +243,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 		switch {
-		case key.Matches(msg, m.bindings.Navigation.Right):
+		case key.Matches(msg, m.keys.Help):
+			m.focus = focusHelp
+		case key.Matches(msg, m.keys.Quit):
+			if m.cancelQuery != nil {
+				m.cancelQuery()
+				m.cancelQuery = nil
+			} else if key.Matches(msg, m.keys.Quit) {
+				return m, tea.Quit
+			}
+		case key.Matches(msg, m.keys.Navigation.Right):
 			if m.focus == focusList {
 				m.focus = focusEditor
 				m.sidebarViewport.selected = false
@@ -242,13 +260,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, cmd)
 			}
 			return m, tea.Batch(cmds...)
-		case key.Matches(msg, m.bindings.Navigation.Down):
+		case key.Matches(msg, m.keys.Navigation.Down):
 			if m.focus == focusEditor {
 				m.focus = focusTable
 				m.editor.Blur()
 				m.resulstset.Focus()
 			}
-		case key.Matches(msg, m.bindings.Navigation.Left):
+		case key.Matches(msg, m.keys.Navigation.Left):
 			if m.focus == focusTable {
 				m.focus = focusList
 				m.sidebarViewport.selected = true
@@ -260,7 +278,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.focus = focusList
 				m.sidebarViewport.selected = true
 			}
-		case key.Matches(msg, m.bindings.Navigation.Up):
+		case key.Matches(msg, m.keys.Navigation.Up):
 			if m.focus == focusTable {
 				m.focus = focusEditor
 				cmd = m.editor.Focus()
@@ -328,9 +346,12 @@ func (m Model) View() tea.View {
 	var v tea.View
 	v.AltScreen = true
 
-	if m.focus == focusHistory {
+	switch m.focus {
+	case focusHistory:
 		v.SetContent(m.queryHistory.View().Content)
-	} else {
+	case focusHelp:
+		v.SetContent(setModalContent(m.help.View(m.keys), m.width, m.height))
+	default:
 		textAreaBorder := darkPurple
 
 		if m.focus == focusEditor {
@@ -475,4 +496,19 @@ func prepareQueriesForExecution(rawText string) []string {
 	}
 
 	return validQueries
+}
+
+func setModalContent(content string, width, height int) string {
+	formStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(neonPurple).
+		Padding(1, 2)
+	boxedForm := formStyle.Render(content)
+	return lipgloss.Place(
+		width,
+		height,
+		lipgloss.Center,
+		lipgloss.Center,
+		boxedForm,
+	)
 }

--- a/pkg/bubbletui/connect.go
+++ b/pkg/bubbletui/connect.go
@@ -323,18 +323,7 @@ func (m *ConnectModel) View() tea.View {
 		spinnerView := fmt.Sprintf("\n %s %s\n", m.spinner.View(), m.loadingAction)
 		content = lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, spinnerView)
 	case stateForm:
-		formStyle := lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(neonPurple).
-			Padding(1, 2)
-		boxedForm := formStyle.Render(m.list.View())
-		content = lipgloss.Place(
-			m.width,
-			m.height,
-			lipgloss.Center,
-			lipgloss.Center,
-			boxedForm,
-		)
+		content = setModalContent(m.list.View(), m.width, m.height)
 	}
 
 	v.SetContent(content)

--- a/pkg/bubbletui/query_history.go
+++ b/pkg/bubbletui/query_history.go
@@ -149,18 +149,7 @@ func (h *HistoryModel) View() tea.View {
 		spinnerView := fmt.Sprintf("\n %s %s\n", h.spinner.View(), h.loadingAction)
 		content = lipgloss.Place(h.width, h.height, lipgloss.Center, lipgloss.Center, spinnerView)
 	case stateForm:
-		formStyle := lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(neonPurple).
-			Padding(1, 2)
-		boxedForm := formStyle.Render(h.list.View())
-		content = lipgloss.Place(
-			h.width,
-			h.height,
-			lipgloss.Center,
-			lipgloss.Center,
-			boxedForm,
-		)
+		content = setModalContent(h.list.View(), h.width, h.height)
 	}
 
 	v.SetContent(content)

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -174,7 +174,7 @@ func DefaultKeyMap() *TUIKeyMap {
 			// --- Actions ---
 			ExecuteQuery: key.NewBinding(
 				key.WithKeys("ctrl+e"),
-				key.WithHelp("ctrl+e", "execute query"),
+				key.WithHelp("ctrl+e", "execute queries in the editor"),
 			),
 			ExecuteSingleQuery: key.NewBinding(
 				key.WithKeys("ctrl+r"),

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -50,8 +50,22 @@ type TUIKeyMap struct {
 	PageBottom      key.Binding
 	EndOfLine       key.Binding
 	BeginningOfLine key.Binding
+	Help            key.Binding
+	Quit            key.Binding
 	Navigation      TUINavigationKeyMap
 	Editor          EditorKeyMap
+}
+
+func (k TUIKeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Help, k.Quit}
+}
+
+func (k TUIKeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{k.NextTab, k.PrevTab, k.PageTop, k.PageBottom, k.EndOfLine, k.BeginningOfLine},
+		{k.Navigation.Up, k.Navigation.Down, k.Navigation.Left, k.Navigation.Right, k.Help, k.Quit},
+		{k.Editor.Up, k.Editor.Down, k.Editor.Left, k.Editor.Right, k.Editor.Insert, k.Editor.Normal, k.Editor.ExecuteQuery, k.Editor.ExecuteSingleQuery},
+	}
 }
 
 type EditorKeyMap struct {
@@ -81,19 +95,19 @@ func DefaultKeyMap() *TUIKeyMap {
 	return &TUIKeyMap{
 		NextTab: key.NewBinding(
 			key.WithKeys("tab"),
-			key.WithHelp("tab", "next tab"),
+			key.WithHelp("tab", "next tab (result set view)"),
 		),
 		PrevTab: key.NewBinding(
 			key.WithKeys("shift+tab"),
-			key.WithHelp("shift+tab", "previous tab"),
+			key.WithHelp("shift+tab", "previous tab (result set view)"),
 		),
 		PageTop: key.NewBinding(
 			key.WithKeys("g"),
-			key.WithHelp("g", "go to top"),
+			key.WithHelp("g", "go to top (sidebar database graph)"),
 		),
 		PageBottom: key.NewBinding(
 			key.WithKeys("G"), // Capital 'G' for shift+g
-			key.WithHelp("G", "go to bottom"),
+			key.WithHelp("G", "go to bottom (sidebar database graph)"),
 		),
 		BeginningOfLine: key.NewBinding(
 			key.WithKeys("0"),
@@ -103,10 +117,18 @@ func DefaultKeyMap() *TUIKeyMap {
 			key.WithKeys("$"),
 			key.WithHelp("$", "navigate all the way to the right of the table"),
 		),
+		Help: key.NewBinding(
+			key.WithKeys("?"),
+			key.WithHelp("?", "toggle help"),
+		),
+		Quit: key.NewBinding(
+			key.WithKeys("ctrl+c"),
+			key.WithHelp("ctrl+c", "quit"),
+		),
 		Navigation: TUINavigationKeyMap{
 			Up: key.NewBinding(
 				key.WithKeys("ctrl+k"),
-				key.WithKeys("ctrl+k", "Toggle to the panel above"),
+				key.WithHelp("ctrl+k", "Toggle to the panel above"),
 			),
 			Down: key.NewBinding(
 				key.WithKeys("ctrl+j"),
@@ -124,19 +146,19 @@ func DefaultKeyMap() *TUIKeyMap {
 		Editor: EditorKeyMap{
 			Up: key.NewBinding(
 				key.WithKeys("k"),
-				key.WithHelp("k", "up"),
+				key.WithHelp("k", "move up"),
 			),
 			Down: key.NewBinding(
 				key.WithKeys("j"),
-				key.WithHelp("j", "down"),
+				key.WithHelp("j", "move down"),
 			),
 			Left: key.NewBinding(
 				key.WithKeys("h"),
-				key.WithHelp("h", "left"),
+				key.WithHelp("h", "move left"),
 			),
 			Right: key.NewBinding(
 				key.WithKeys("l"),
-				key.WithHelp("l", "right"),
+				key.WithHelp("l", "move right"),
 			),
 
 			// --- Mode Switching ---
@@ -154,7 +176,6 @@ func DefaultKeyMap() *TUIKeyMap {
 				key.WithKeys("ctrl+e"),
 				key.WithHelp("ctrl+e", "execute query"),
 			),
-
 			ExecuteSingleQuery: key.NewBinding(
 				key.WithKeys("ctrl+r"),
 				key.WithHelp("ctrl+r", "execute single query"),

--- a/pkg/config/.dblab.yaml
+++ b/pkg/config/.dblab.yaml
@@ -67,6 +67,10 @@ limit: 50
 keybindings:
   next-tab: 'tab'
   prev-tab: 'shift+tab'
+  end-of-line: '$'
+  beginning-of-line: '0'
+  help: '?'
+  quit: 'ctrl+c'
   navigation:
     up: 'ctrl+k'
     down: 'ctrl+j'

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,6 +82,8 @@ type KeyBindings struct {
 	PageBottom      string `fig:"page-bottom"   default:"G"`
 	EndOfLine       string `fig:"end-of-line"   default:"$"`
 	BeginningOfLine string `fig:"beginning-of-line"   default:"0"`
+	Help            string `fig:"help"   default:"?"`
+	Quit            string `fig:"quit"   default:"ctrl+c"`
 	Navigation      NavigationBindgins
 	Editor          EditorKeyMap
 }
@@ -209,12 +211,14 @@ func SetupKeyMap() (*command.TUIKeyMap, error) {
 	}
 
 	tkb = command.TUIKeyMap{
-		NextTab:         key.NewBinding(key.WithKeys(kbc.KeyBindings.NextTab), key.WithHelp(kbc.KeyBindings.NextTab, "next tab")),
-		PrevTab:         key.NewBinding(key.WithKeys(kbc.KeyBindings.PrevTab), key.WithHelp(kbc.KeyBindings.PrevTab, "previous tab")),
-		PageTop:         key.NewBinding(key.WithKeys(kbc.KeyBindings.PageTop), key.WithHelp(kbc.KeyBindings.PageTop, "go to top")),
-		PageBottom:      key.NewBinding(key.WithKeys(kbc.KeyBindings.PageBottom), key.WithHelp(kbc.KeyBindings.PageBottom, "go to bottom")),
-		EndOfLine:       key.NewBinding(key.WithKeys(kbc.KeyBindings.EndOfLine), key.WithHelp(kbc.KeyBindings.EndOfLine, "end of current line")),
-		BeginningOfLine: key.NewBinding(key.WithKeys(kbc.KeyBindings.BeginningOfLine), key.WithHelp(kbc.KeyBindings.BeginningOfLine, "beginning of current line")),
+		NextTab:         key.NewBinding(key.WithKeys(kbc.KeyBindings.NextTab), key.WithHelp(kbc.KeyBindings.NextTab, "next tab (result set view)")),
+		PrevTab:         key.NewBinding(key.WithKeys(kbc.KeyBindings.PrevTab), key.WithHelp(kbc.KeyBindings.PrevTab, "previous tab (result set view)")),
+		PageTop:         key.NewBinding(key.WithKeys(kbc.KeyBindings.PageTop), key.WithHelp(kbc.KeyBindings.PageTop, "go to top (sidebar database graph)")),
+		PageBottom:      key.NewBinding(key.WithKeys(kbc.KeyBindings.PageBottom), key.WithHelp(kbc.KeyBindings.PageBottom, "go to bottom (sidebar database graph)")),
+		EndOfLine:       key.NewBinding(key.WithKeys(kbc.KeyBindings.EndOfLine), key.WithHelp(kbc.KeyBindings.EndOfLine, "navigate all the way to the right of the table")),
+		BeginningOfLine: key.NewBinding(key.WithKeys(kbc.KeyBindings.BeginningOfLine), key.WithHelp(kbc.KeyBindings.BeginningOfLine, "navigate all the way to the left of the table")),
+		Help:            key.NewBinding(key.WithKeys(kbc.KeyBindings.Help), key.WithHelp(kbc.KeyBindings.Help, "toggle help")),
+		Quit:            key.NewBinding(key.WithKeys(kbc.KeyBindings.Quit), key.WithHelp(kbc.KeyBindings.Quit, "quit")),
 		Navigation: command.TUINavigationKeyMap{
 			Up:    key.NewBinding(key.WithKeys(kbc.KeyBindings.Navigation.Up), key.WithHelp(kbc.KeyBindings.Navigation.Up, "Toggle to the panel above")),
 			Down:  key.NewBinding(key.WithKeys(kbc.KeyBindings.Navigation.Down), key.WithHelp(kbc.KeyBindings.Navigation.Down, "Toggle to the panel below")),
@@ -228,7 +232,7 @@ func SetupKeyMap() (*command.TUIKeyMap, error) {
 			Right:              key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Right), key.WithHelp(kbc.KeyBindings.Editor.Right, "move right")),
 			Insert:             key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Insert), key.WithHelp(kbc.KeyBindings.Editor.Insert, "insert mode")),
 			Normal:             key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.Normal), key.WithHelp(kbc.KeyBindings.Editor.Normal, "normal mode")),
-			ExecuteQuery:       key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.ExecuteQuery), key.WithHelp(kbc.KeyBindings.Editor.ExecuteQuery, "execute query")),
+			ExecuteQuery:       key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.ExecuteQuery), key.WithHelp(kbc.KeyBindings.Editor.ExecuteQuery, "execute queries in the editor")),
 			ExecuteSingleQuery: key.NewBinding(key.WithKeys(kbc.KeyBindings.Editor.ExecuteSingleQuery), key.WithHelp(kbc.KeyBindings.Editor.ExecuteSingleQuery, "execute single query")),
 		},
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -183,6 +183,10 @@ func TestSetupKeybindings(t *testing.T) {
 
 	assert.Contains(t, kb.NextTab.Keys(), "tab")
 	assert.Contains(t, kb.PrevTab.Keys(), "shift+tab")
+	assert.Contains(t, kb.EndOfLine.Keys(), "$")
+	assert.Contains(t, kb.BeginningOfLine.Keys(), "0")
+	assert.Contains(t, kb.Help.Keys(), "?")
+	assert.Contains(t, kb.Quit.Keys(), "ctrl+c")
 	assert.Contains(t, kb.Navigation.Up.Keys(), "ctrl+k")
 	assert.Contains(t, kb.Navigation.Down.Keys(), "ctrl+j")
 	assert.Contains(t, kb.Navigation.Right.Keys(), "ctrl+l")


### PR DESCRIPTION
## Add help modal and configurable quit/help key bindings

## Description

<img width="1645" height="438" alt="Screenshot From 2026-07-23 21-33-47" src="https://github.com/user-attachments/assets/23e0ba9d-5599-480f-b797-479554e60e70" />

This PR adds a built-in help modal to dblab that displays all available key bindings in a styled overlay. It also makes the `quit` and `help` keys configurable through the `.dblab.yaml` config file, consistent with how other key bindings are already handled.

### Changes

**New help modal (`?` to open, `Esc` to dismiss):**

- Press `?` anywhere in the app to open a centered modal that lists every key binding grouped by category (general, navigation, and editor).
- Press `Esc` to dismiss the modal and return to the previous view.
- The modal uses the Bubbles `help` component with full-help mode enabled, styled to match the app's color scheme (cyber green keys, white descriptions, muted green separators).

**Configurable `help` and `quit` keys:**

- Added `help` and `quit` fields to the `keybindings` section of `.dblab.yaml` (defaults: `?` and `ctrl+c`).
- `TUIKeyMap` now implements `help.KeyMap` (`ShortHelp` and `FullHelp`) so the help component can render all bindings automatically.
- Updated help text on existing bindings to be more descriptive (e.g., "next tab" → "next tab (result set view)").

**Refactoring:**

- Extracted the modal layout logic into a shared `setModalContent` function, replacing duplicated styling code in `connect.go`, `query_history.go`, and `bubbletui.go`.
- Renamed the internal field `bindings` to `keys` for brevity.
- Replaced the hard-coded `ctrl+c` handler with a `key.Matches`-based handler using the configurable `Quit` binding.

**Tests and config:**

- Added test assertions for the new `Help` and `Quit` bindings in `config_test.go`.
- Updated both `.dblab.yaml` files (root and `pkg/config/`) with the new key binding fields.

Fixes #325 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Locally, updating the config file to show the key bindings on the help modal

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
