### PR TITLE
Fix default schema management

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -124,13 +124,13 @@ func New(opts command.Options) (*Client, error) {
 		return nil, fmt.Errorf("%s driver not supported", c.driver)
 	}
 
-	switch c.driver {
-	case drivers.PostgreSQL, drivers.Postgres, drivers.PostgresSSH:
-		if _, err = db.Exec(fmt.Sprintf("set search_path = '%s'", c.schema)); err != nil {
-			return nil, err
-		}
-	case drivers.Oracle:
-		if c.schema != "" {
+	if c.schema != "" {
+		switch c.driver {
+		case drivers.PostgreSQL, drivers.Postgres, drivers.PostgresSSH:
+			if _, err = db.Exec(fmt.Sprintf("set search_path = '%s'", c.schema)); err != nil {
+				return nil, err
+			}
+		case drivers.Oracle:
 			if _, err = db.Exec(fmt.Sprintf("ALTER SESSION SET CURRENT_SCHEMA = %s", c.schema)); err != nil {
 				return nil, err
 			}

--- a/pkg/form/form.go
+++ b/pkg/form/form.go
@@ -56,6 +56,7 @@ type Model struct {
 	portInput     textinput.Model
 	userInput     textinput.Model
 	passwordInput textinput.Model
+	schemaInput   textinput.Model
 	databaseInput textinput.Model
 	filePathInput textinput.Model
 	limitInput    textinput.Model
@@ -139,6 +140,10 @@ func (m *Model) Password() string {
 // Database returns the database name value.
 func (m *Model) Database() string {
 	return m.databaseInput.Value()
+}
+
+func (m *Model) Schema() string {
+	return m.schemaInput.Value()
 }
 
 // SSLMode returns the ssl mode name value.
@@ -242,6 +247,11 @@ func initModel() Model {
 	password.CharLimit = 200
 	password.SetWidth(20)
 
+	schema := textinput.New()
+	schema.Placeholder = "Schema"
+	schema.CharLimit = 200
+	schema.SetWidth(20)
+
 	database := textinput.New()
 	database.Placeholder = "Database"
 	database.CharLimit = 200
@@ -317,6 +327,7 @@ func initModel() Model {
 		portInput:                   port,
 		userInput:                   user,
 		passwordInput:               password,
+		schemaInput:                 schema,
 		databaseInput:               database,
 		limitInput:                  limit,
 		filePathInput:               filePath,
@@ -351,6 +362,7 @@ func Run() (command.Options, error) {
 		Port:                   m.Port(),
 		User:                   m.User(),
 		Pass:                   m.Password(),
+		Schema:                 m.Schema(),
 		DBName:                 m.Database(),
 		SSL:                    m.SSLMode(),
 		SSLCert:                m.SSLCert(),

--- a/pkg/form/update.go
+++ b/pkg/form/update.go
@@ -102,11 +102,21 @@ func updateStd(msg tea.Msg, m *Model) (tea.Model, tea.Cmd) {
 func stdInputs(m *Model) []textinput.Model {
 	var inputs []textinput.Model
 
-	if m.driver == drivers.SQLite {
+	switch m.driver {
+	case drivers.SQLite:
 		inputs = []textinput.Model{
 			m.filePathInput,
 		}
-	} else {
+	case drivers.PostgreSQL, drivers.Postgres, drivers.SQLServer, drivers.Oracle:
+		inputs = []textinput.Model{
+			m.hostInput,
+			m.portInput,
+			m.userInput,
+			m.passwordInput,
+			m.schemaInput,
+			m.databaseInput,
+		}
+	case drivers.MySQL:
 		inputs = []textinput.Model{
 			m.hostInput,
 			m.portInput,
@@ -122,11 +132,25 @@ func stdInputs(m *Model) []textinput.Model {
 }
 
 func assignStdInputValues(m *Model, inputs []textinput.Model) {
-	if m.driver == drivers.SQLite && len(inputs) == 2 {
-		m.filePathInput = inputs[0]
-		m.limitInput = inputs[1]
-	} else if len(inputs) == 6 {
-		{
+
+	switch m.driver {
+	case drivers.SQLite:
+		if len(inputs) == 2 {
+			m.filePathInput = inputs[0]
+			m.limitInput = inputs[1]
+		}
+	case drivers.PostgreSQL, drivers.Postgres, drivers.SQLServer, drivers.Oracle:
+		if len(inputs) == 7 {
+			m.hostInput = inputs[0]
+			m.portInput = inputs[1]
+			m.userInput = inputs[2]
+			m.passwordInput = inputs[3]
+			m.schemaInput = inputs[4]
+			m.databaseInput = inputs[5]
+			m.limitInput = inputs[6]
+		}
+	case drivers.MySQL:
+		if len(inputs) == 6 {
 			m.hostInput = inputs[0]
 			m.portInput = inputs[1]
 			m.userInput = inputs[2]
@@ -143,10 +167,29 @@ func updateInputs(msg tea.Msg, m *Model) (*Model, tea.Cmd) {
 		cmds []tea.Cmd
 	)
 
-	if m.driver == drivers.SQLite {
+	switch m.driver {
+	case drivers.SQLite:
 		m.filePathInput, cmd = m.filePathInput.Update(msg)
 		cmds = append(cmds, cmd)
-	} else {
+	case drivers.PostgreSQL, drivers.Postgres, drivers.SQLServer, drivers.Oracle:
+		m.hostInput, cmd = m.hostInput.Update(msg)
+		cmds = append(cmds, cmd)
+
+		m.portInput, cmd = m.portInput.Update(msg)
+		cmds = append(cmds, cmd)
+
+		m.userInput, cmd = m.userInput.Update(msg)
+		cmds = append(cmds, cmd)
+
+		m.passwordInput, cmd = m.passwordInput.Update(msg)
+		cmds = append(cmds, cmd)
+
+		m.schemaInput, cmd = m.schemaInput.Update(msg)
+		cmds = append(cmds, cmd)
+
+		m.databaseInput, cmd = m.databaseInput.Update(msg)
+		cmds = append(cmds, cmd)
+	case drivers.MySQL:
 		m.hostInput, cmd = m.hostInput.Update(msg)
 		cmds = append(cmds, cmd)
 

--- a/pkg/form/view.go
+++ b/pkg/form/view.go
@@ -39,12 +39,23 @@ func standardView(m *Model) string {
 func viewInputs(m *Model) []string {
 	var inputs []string
 
-	if m.driver == drivers.SQLite {
+	switch m.driver {
+	case drivers.SQLite:
 		inputs = []string{
 			m.filePathInput.View(),
 			m.limitInput.View(),
 		}
-	} else {
+	case drivers.PostgreSQL, drivers.Postgres, drivers.SQLServer, drivers.Oracle:
+		inputs = []string{
+			m.hostInput.View(),
+			m.portInput.View(),
+			m.userInput.View(),
+			m.passwordInput.View(),
+			m.schemaInput.View(),
+			m.databaseInput.View(),
+			m.limitInput.View(),
+		}
+	case drivers.MySQL:
 		inputs = []string{
 			m.hostInput.View(),
 			m.portInput.View(),


### PR DESCRIPTION
# Fix default schema management

## Description

The schema is optional since the **db graph** was added to the sideview port (the widget on the left), meaning that if not present, the user will see the `schemas` she has access to, but I forgot to add the option to the form. A recent issue reminded me to do so.

Fixes #342 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Locally, against databases running in containers

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
