### PR TITLE
Refactor: Use keymaps from config to handle movements 

### DIFF
--- a/pkg/bubbletui/editor.go
+++ b/pkg/bubbletui/editor.go
@@ -165,16 +165,19 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 			case "x":
 				e.editor, cmd = e.editor.Update(tea.KeyPressMsg{Code: tea.KeyDelete})
 				return e, cmd
-			case "0":
-				e.editor, cmd = e.editor.Update(tea.KeyPressMsg{Code: tea.KeyHome})
-				return e, cmd
-			case "$":
-				e.editor, cmd = e.editor.Update(tea.KeyPressMsg{Code: tea.KeyEnd})
-				return e, cmd
 			case "ctrl+d":
 				e.editor.Reset() // Clears text, cursor, and history
 				return e, nil
-			case "G":
+			}
+
+			switch {
+			case key.Matches(msg, e.bindings.BeginningOfLine):
+				e.editor, cmd = e.editor.Update(tea.KeyPressMsg{Code: tea.KeyHome})
+				return e, cmd
+			case key.Matches(msg, e.bindings.EndOfLine):
+				e.editor, cmd = e.editor.Update(tea.KeyPressMsg{Code: tea.KeyEnd})
+				return e, cmd
+			case key.Matches(msg, e.bindings.PageBottom):
 				// LineCount() returns the total number of lines.
 				// Line() returns the current 0-indexed line position.
 				lastLine := e.editor.LineCount() - 1
@@ -182,14 +185,11 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 					e.editor.CursorDown()
 				}
 				return e, nil
-			case "g":
+			case key.Matches(msg, e.bindings.PageTop):
 				for e.editor.Line() > 0 {
 					e.editor.CursorUp()
 				}
 				return e, nil
-			}
-
-			switch {
 			case key.Matches(msg, e.bindings.Editor.Insert):
 				e.mode = InsertMode
 				styles := e.editor.Styles()

--- a/pkg/bubbletui/resultset.go
+++ b/pkg/bubbletui/resultset.go
@@ -206,11 +206,11 @@ func (r ResultSet) Update(msg tea.Msg) (ResultSet, tea.Cmd) {
 			return r, nil
 		}
 
-		switch msg.String() {
-		case "left", "h":
+		switch {
+		case key.Matches(msg, r.bindings.Editor.Left) || msg.String() == "left":
 			r.viewport.ScrollLeft(4)
 			return r, nil
-		case "right", "l":
+		case key.Matches(msg, r.bindings.Editor.Right) || msg.String() == "right":
 			r.viewport.ScrollRight(4)
 			return r, nil
 		}

--- a/pkg/bubbletui/sidebar.go
+++ b/pkg/bubbletui/sidebar.go
@@ -111,10 +111,11 @@ func (s *SidebarViewport) SetSize(w, h int) {
 
 func (s *SidebarViewport) newTuiTreeModel(tree *treeview.Tree[*client.DBNode], width, height int) *treeview.TuiTreeModel[*client.DBNode] {
 	// Create custom key map to avoid key conflicts
+	
 	keyMap := treeview.DefaultKeyMap()
 	keyMap.SearchStart = []string{"/"}
-	keyMap.Up = []string{"up", "k", "w"}
-	keyMap.Down = []string{"down", "j", "s"}
+	keyMap.Up = append([]string{"up", "w"}, s.bindings.Editor.Up.Keys()...)
+	keyMap.Down = append([]string{"down", "s"}, s.bindings.Editor.Down.Keys()...)
 	keyMap.Toggle = []string{"enter"}
 
 	return treeview.NewTuiTreeModel(tree,
@@ -206,11 +207,11 @@ func (s SidebarViewport) Update(msg tea.Msg) (SidebarViewport, tea.Cmd) {
 
 		s.sidebarViewport.SetContent(s.dbTree.View().Content)
 
-		switch msg.String() {
-		case "left", "h":
+		switch {
+		case key.Matches(msg, s.bindings.Editor.Left) || msg.String() == "left":
 			s.sidebarViewport.ScrollLeft(4)
 			return s, nil
-		case "right", "l":
+		case key.Matches(msg, s.bindings.Editor.Right) || msg.String() == "right":
 			s.sidebarViewport.ScrollRight(4)
 			return s, nil
 		}


### PR DESCRIPTION
## Description

I noticed that some modules uses magic strings to validate movements, this could be a problem when the user want to changes the bindings using a config file. Then in some places I used the `Matches` method to check a binding instead of comparing the strings.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
