### PR TITLE
Fix treeview search to accept some characters

### DIFF
--- a/pkg/bubbletui/sidebar.go
+++ b/pkg/bubbletui/sidebar.go
@@ -119,7 +119,6 @@ func (s *SidebarViewport) newTuiTreeModel(tree *treeview.Tree[*client.DBNode], w
 	// Create custom key map to avoid key conflicts
 	keyMap := treeview.DefaultKeyMap()
 	keyMap.SearchStart = []string{startSearch}
-	keyMap.SearchCancel = []string{cancelSearch}
 	keyMap.Up = []string{"up", "k", "w"}
 	keyMap.Down = []string{"down", "j", "s"}
 	keyMap.Toggle = []string{"enter"}
@@ -178,60 +177,58 @@ func (s SidebarViewport) Update(msg tea.Msg) (SidebarViewport, tea.Cmd) {
 			}
 		}
 
-		if !s.shouldNotMatchABinding(msg) {
-			switch {
-			case key.Matches(msg, s.bindings.PageTop):
-				ctx := context.Background()
+		switch {
+		case key.Matches(msg, s.bindings.PageTop):
+			ctx := context.Background()
 
-				for nodeInfo, err := range s.dbTree.AllVisible(ctx) {
-					if err != nil {
-						break
-					}
-
-					_, _ = s.dbTree.SetFocusedID(ctx, nodeInfo.Node.ID())
+			for nodeInfo, err := range s.dbTree.AllVisible(ctx) {
+				if err != nil {
 					break
 				}
-				return s, nil
-			case key.Matches(msg, s.bindings.PageBottom):
-				ctx := context.Background()
 
-				var bottomNodeID string
-				var found bool
+				_, _ = s.dbTree.SetFocusedID(ctx, nodeInfo.Node.ID())
+				break
+			}
+			return s, nil
+		case key.Matches(msg, s.bindings.PageBottom):
+			ctx := context.Background()
 
-				for nodeInfo, err := range s.dbTree.AllVisible(ctx) {
-					if err != nil {
-						break
-					}
+			var bottomNodeID string
+			var found bool
 
-					bottomNodeID = nodeInfo.Node.ID()
-					found = true
+			for nodeInfo, err := range s.dbTree.AllVisible(ctx) {
+				if err != nil {
+					break
 				}
 
-				if found {
-					_, _ = s.dbTree.SetFocusedID(ctx, bottomNodeID)
-				}
-				return s, nil
+				bottomNodeID = nodeInfo.Node.ID()
+				found = true
 			}
 
-			s.sidebarViewport.SetContent(s.dbTree.View().Content)
+			if found {
+				_, _ = s.dbTree.SetFocusedID(ctx, bottomNodeID)
+			}
+			return s, nil
+		}
 
-			switch msg.String() {
-			case "left", "h":
+		s.sidebarViewport.SetContent(s.dbTree.View().Content)
+
+		switch msg.String() {
+		case "left", "h":
+			if !s.searching {
 				s.sidebarViewport.ScrollLeft(4)
-				return s, nil
-			case "right", "l":
-				s.sidebarViewport.ScrollRight(4)
-				return s, nil
 			}
+		case "right", "l":
+			if !s.searching {
+				s.sidebarViewport.ScrollRight(4)
+			}
+		case startSearch:
+			s.searching = true
+		case cancelSearch:
+			s.searching = false
 		}
 
 		if s.dbTree != nil {
-			switch msg.String() {
-			case startSearch:
-				s.searching = true
-			case cancelSearch:
-				s.searching = false
-			}
 			updatedModel, treeCmd := s.dbTree.Update(msg)
 			if newTreeModel, ok := updatedModel.(*treeview.TuiTreeModel[*client.DBNode]); ok {
 				s.dbTree = newTreeModel
@@ -294,10 +291,6 @@ func (s *SidebarViewport) updateGraph() tea.Cmd {
 
 		return updateGraphMsg{tree: dbTree}
 	}
-}
-
-func (s SidebarViewport) shouldNotMatchABinding(msg tea.KeyPressMsg) bool {
-	return s.searching && len(msg.String()) == 1
 }
 
 func createCyberpunkProvider() *treeview.DefaultNodeProvider[*client.DBNode] {

--- a/pkg/bubbletui/sidebar.go
+++ b/pkg/bubbletui/sidebar.go
@@ -178,49 +178,51 @@ func (s SidebarViewport) Update(msg tea.Msg) (SidebarViewport, tea.Cmd) {
 			}
 		}
 
-		switch {
-		case key.Matches(msg, s.bindings.PageTop):
-			ctx := context.Background()
+		if !s.shouldNotMatchABinding(msg) {
+			switch {
+			case key.Matches(msg, s.bindings.PageTop):
+				ctx := context.Background()
 
-			for nodeInfo, err := range s.dbTree.AllVisible(ctx) {
-				if err != nil {
+				for nodeInfo, err := range s.dbTree.AllVisible(ctx) {
+					if err != nil {
+						break
+					}
+
+					_, _ = s.dbTree.SetFocusedID(ctx, nodeInfo.Node.ID())
 					break
 				}
+				return s, nil
+			case key.Matches(msg, s.bindings.PageBottom):
+				ctx := context.Background()
 
-				_, _ = s.dbTree.SetFocusedID(ctx, nodeInfo.Node.ID())
-				break
-			}
-			return s, nil
-		case key.Matches(msg, s.bindings.PageBottom):
-			ctx := context.Background()
+				var bottomNodeID string
+				var found bool
 
-			var bottomNodeID string
-			var found bool
+				for nodeInfo, err := range s.dbTree.AllVisible(ctx) {
+					if err != nil {
+						break
+					}
 
-			for nodeInfo, err := range s.dbTree.AllVisible(ctx) {
-				if err != nil {
-					break
+					bottomNodeID = nodeInfo.Node.ID()
+					found = true
 				}
 
-				bottomNodeID = nodeInfo.Node.ID()
-				found = true
+				if found {
+					_, _ = s.dbTree.SetFocusedID(ctx, bottomNodeID)
+				}
+				return s, nil
 			}
 
-			if found {
-				_, _ = s.dbTree.SetFocusedID(ctx, bottomNodeID)
+			s.sidebarViewport.SetContent(s.dbTree.View().Content)
+
+			switch msg.String() {
+			case "left", "h":
+				s.sidebarViewport.ScrollLeft(4)
+				return s, nil
+			case "right", "l":
+				s.sidebarViewport.ScrollRight(4)
+				return s, nil
 			}
-			return s, nil
-		}
-
-		s.sidebarViewport.SetContent(s.dbTree.View().Content)
-
-		switch msg.String() {
-		case "left", "h":
-			s.sidebarViewport.ScrollLeft(4)
-			return s, nil
-		case "right", "l":
-			s.sidebarViewport.ScrollRight(4)
-			return s, nil
 		}
 
 		if s.dbTree != nil {

--- a/pkg/bubbletui/sidebar.go
+++ b/pkg/bubbletui/sidebar.go
@@ -179,36 +179,40 @@ func (s SidebarViewport) Update(msg tea.Msg) (SidebarViewport, tea.Cmd) {
 
 		switch {
 		case key.Matches(msg, s.bindings.PageTop):
-			ctx := context.Background()
+			if !s.searching {
+				ctx := context.Background()
 
-			for nodeInfo, err := range s.dbTree.AllVisible(ctx) {
-				if err != nil {
+				for nodeInfo, err := range s.dbTree.AllVisible(ctx) {
+					if err != nil {
+						break
+					}
+
+					_, _ = s.dbTree.SetFocusedID(ctx, nodeInfo.Node.ID())
 					break
 				}
-
-				_, _ = s.dbTree.SetFocusedID(ctx, nodeInfo.Node.ID())
-				break
+				return s, nil
 			}
-			return s, nil
 		case key.Matches(msg, s.bindings.PageBottom):
-			ctx := context.Background()
+			if !s.searching {
+				ctx := context.Background()
 
-			var bottomNodeID string
-			var found bool
+				var bottomNodeID string
+				var found bool
 
-			for nodeInfo, err := range s.dbTree.AllVisible(ctx) {
-				if err != nil {
-					break
+				for nodeInfo, err := range s.dbTree.AllVisible(ctx) {
+					if err != nil {
+						break
+					}
+
+					bottomNodeID = nodeInfo.Node.ID()
+					found = true
 				}
 
-				bottomNodeID = nodeInfo.Node.ID()
-				found = true
+				if found {
+					_, _ = s.dbTree.SetFocusedID(ctx, bottomNodeID)
+				}
+				return s, nil
 			}
-
-			if found {
-				_, _ = s.dbTree.SetFocusedID(ctx, bottomNodeID)
-			}
-			return s, nil
 		}
 
 		s.sidebarViewport.SetContent(s.dbTree.View().Content)

--- a/pkg/bubbletui/sidebar.go
+++ b/pkg/bubbletui/sidebar.go
@@ -17,6 +17,11 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
+var (
+	startSearch  = "/"
+	cancelSearch = "esc"
+)
+
 func dbObjectHasType(nodeType string) func(*treeview.Node[*client.DBNode]) bool {
 	return func(n *treeview.Node[*client.DBNode]) bool {
 		return (*n.Data()).Type == nodeType
@@ -41,8 +46,9 @@ type SidebarViewport struct {
 	dbTree          *treeview.TuiTreeModel[*client.DBNode]
 	width, height   int
 
-	selected bool
-	dump     io.Writer
+	selected  bool
+	searching bool
+	dump      io.Writer
 }
 
 type DBGraphTreeBuilderProvider struct{}
@@ -112,7 +118,8 @@ func (s *SidebarViewport) SetSize(w, h int) {
 func (s *SidebarViewport) newTuiTreeModel(tree *treeview.Tree[*client.DBNode], width, height int) *treeview.TuiTreeModel[*client.DBNode] {
 	// Create custom key map to avoid key conflicts
 	keyMap := treeview.DefaultKeyMap()
-	keyMap.SearchStart = []string{"/"}
+	keyMap.SearchStart = []string{startSearch}
+	keyMap.SearchCancel = []string{cancelSearch}
 	keyMap.Up = []string{"up", "k", "w"}
 	keyMap.Down = []string{"down", "j", "s"}
 	keyMap.Toggle = []string{"enter"}
@@ -217,6 +224,12 @@ func (s SidebarViewport) Update(msg tea.Msg) (SidebarViewport, tea.Cmd) {
 		}
 
 		if s.dbTree != nil {
+			switch msg.String() {
+			case startSearch:
+				s.searching = true
+			case cancelSearch:
+				s.searching = false
+			}
 			updatedModel, treeCmd := s.dbTree.Update(msg)
 			if newTreeModel, ok := updatedModel.(*treeview.TuiTreeModel[*client.DBNode]); ok {
 				s.dbTree = newTreeModel
@@ -279,6 +292,10 @@ func (s *SidebarViewport) updateGraph() tea.Cmd {
 
 		return updateGraphMsg{tree: dbTree}
 	}
+}
+
+func (s SidebarViewport) shouldNotMatchABinding(msg tea.KeyPressMsg) bool {
+	return s.searching && len(msg.String()) == 1
 }
 
 func createCyberpunkProvider() *treeview.DefaultNodeProvider[*client.DBNode] {


### PR DESCRIPTION
## Description

I added the flag `searching` to be able to tell when a keypress event should be interpreted as a shortcut or as a search character. If the key is a single character (not a keystroke) and the user is searching, then the character should be placed in the search input and any movement binding won't be applied.

Fixes #349

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested using current unit test code base and manually.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
