### PR TITLE
remove annoying keymaps

### DIFF
--- a/pkg/bubbletui/query_history.go
+++ b/pkg/bubbletui/query_history.go
@@ -64,6 +64,8 @@ func NewHistoryModel() *HistoryModel {
 		Bold(true)
 	queryList.SetShowStatusBar(false)
 	queryList.SetShowHelp(true)
+	queryList.KeyMap.Quit.Unbind()
+	queryList.KeyMap.ForceQuit.Unbind()
 
 	// Set up the spinner model.
 	s := spinner.New()

--- a/pkg/bubbletui/sidebar.go
+++ b/pkg/bubbletui/sidebar.go
@@ -116,6 +116,7 @@ func (s *SidebarViewport) newTuiTreeModel(tree *treeview.Tree[*client.DBNode], w
 	keyMap.Up = []string{"up", "k", "w"}
 	keyMap.Down = []string{"down", "j", "s"}
 	keyMap.Toggle = []string{"enter"}
+	keyMap.Quit = []string{}
 
 	return treeview.NewTuiTreeModel(tree,
 		treeview.WithTuiWidth[*client.DBNode](width),


### PR DESCRIPTION
# Remove annoying quit keymaps

## Description

The side view and the history models quit the app on either `esc` or `q` key events. Just removed the bindings from their keymaps. `ctrl+c` should be the only way to exit the app across the app.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Locally, against the Pagila database

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
