### PR TITLE
Feat: new tabs design and color on focus only

### DIFF
--- a/pkg/bubbletui/bubbletui.go
+++ b/pkg/bubbletui/bubbletui.go
@@ -228,7 +228,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.editorWidth = m.rightWidth - 4
 		m.editorHeight = availableHeight/3 - 2
 
-		m.resultSetHeight = availableHeight - m.editorHeight - 4
+		m.resultSetHeight = availableHeight - m.editorHeight - 2
 		m.resultSetWidth = m.rightWidth - 4
 
 		m.help.SetWidth(msg.Width)

--- a/pkg/bubbletui/resultset.go
+++ b/pkg/bubbletui/resultset.go
@@ -20,9 +20,10 @@ import (
 // tabStyles is for tab styling.
 // The tabs are used to show table metadata.
 type tabStyles struct {
-	inactiveTab lipgloss.Style
-	activeTab   lipgloss.Style
-	border      lipgloss.Border
+	inactiveTab      lipgloss.Style
+	activeTab        lipgloss.Style
+	activeTabFocused lipgloss.Style
+	border           lipgloss.Border
 }
 
 // newTabStyles function retuns a pointer to the tabStyles.
@@ -32,8 +33,10 @@ func newTabStyles() *tabStyles {
 	s := new(tabStyles)
 	s.inactiveTab = lipgloss.NewStyle().
 		Padding(0, 1)
-	s.activeTab = s.inactiveTab.
+	s.activeTabFocused = s.inactiveTab.
 		Background(neonPurple)
+	s.activeTab = s.inactiveTab.
+		Background(darkPurple)
 	s.border = lipgloss.RoundedBorder()
 	return s
 }
@@ -295,15 +298,26 @@ func (r ResultSet) View() tea.View {
 	for i, t := range r.tabs {
 		style := s.inactiveTab
 		if i == r.activeTab && r.focused {
-			style = s.activeTab
+			style = s.activeTabFocused
 		}
-		if i > 0 {
-			renderedTabs = append(renderedTabs, lipgloss.NewStyle().Foreground(tableBorder).Render("─"))
+		if i == r.activeTab && !r.focused {
+			style = s.activeTab
 		}
 		renderedTabs = append(renderedTabs, style.Render(t))
 	}
 
-	row := lipgloss.JoinHorizontal(lipgloss.Top, renderedTabs...)
+	tabsWidth := lipgloss.Width(strings.Join(renderedTabs, ""))
+
+	availableWidth := r.width - 2 - tabsWidth
+	if availableWidth < 0 {
+		availableWidth = 0
+	}
+	separatorWidth := ((availableWidth / (len(r.tabs) - 1)) / 2)
+
+	separator := strings.Repeat(lipgloss.NewStyle().Foreground(tableBorder).Render("─"), separatorWidth)
+	tabs := strings.Join(renderedTabs, separator)
+
+	row := lipgloss.JoinHorizontal(lipgloss.Top, tabs)
 	centered := lipgloss.PlaceHorizontal(r.width-2, lipgloss.Center, row,
 		lipgloss.WithWhitespaceChars(s.border.Top),
 		lipgloss.WithWhitespaceStyle(borderCharStyle))

--- a/pkg/bubbletui/resultset.go
+++ b/pkg/bubbletui/resultset.go
@@ -22,20 +22,19 @@ import (
 type tabStyles struct {
 	inactiveTab lipgloss.Style
 	activeTab   lipgloss.Style
+	border      lipgloss.Border
 }
 
 // newTabStyles function retuns a pointer to the tabStyles.
-// It basically defines the default borders for bot active and inactive tabs.
+// It defines the highlighted background used for the active tab and the
+// border character shared with the result set window below the tab row.
 func newTabStyles() *tabStyles {
-	inactiveTabBorder := tabBorderWithBottom("┴", "─", "┴")
-	activeTabBorder := tabBorderWithBottom("┘", " ", "└")
 	s := new(tabStyles)
 	s.inactiveTab = lipgloss.NewStyle().
-		Border(inactiveTabBorder, true).
-		BorderForeground(darkPurple).
 		Padding(0, 1)
 	s.activeTab = s.inactiveTab.
-		Border(activeTabBorder, true)
+		Background(neonPurple)
+	s.border = lipgloss.RoundedBorder()
 	return s
 }
 
@@ -284,60 +283,36 @@ func (r ResultSet) Update(msg tea.Msg) (ResultSet, tea.Cmd) {
 }
 
 func (r ResultSet) View() tea.View {
-	var renderedTabs []string
-
 	tableBorder := darkPurple
 	if r.focused {
 		tableBorder = neonPurple
 	}
 
-	doc := strings.Builder{}
 	s := r.tabStyles
-	numTabs := len(r.tabs)
-	viewportWidth := r.width
+	borderCharStyle := lipgloss.NewStyle().Foreground(tableBorder)
 
-	baseWidth := viewportWidth / numTabs
-	remainder := viewportWidth % numTabs
-
+	var renderedTabs []string
 	for i, t := range r.tabs {
-		tabWidth := baseWidth
-
-		if i < remainder {
-			tabWidth++
+		style := s.inactiveTab
+		if i == r.activeTab && r.focused {
+			style = s.activeTab
 		}
-
-		var style lipgloss.Style
-		isFirst, isLast, isActive := i == 0, i == len(r.tabs)-1, i == r.activeTab
-
-		if isActive {
-			style = s.activeTab.Width(tabWidth)
-			style = style.BorderForeground(neonPurple)
-		} else {
-			style = s.inactiveTab.Width(tabWidth)
+		if i > 0 {
+			renderedTabs = append(renderedTabs, "─")
 		}
-
-		border, _, _, _, _ := style.GetBorder()
-		if isFirst && isActive {
-			border.BottomLeft = "│"
-		} else if isFirst && !isActive {
-			border.BottomLeft = "│"
-		} else if isLast && isActive {
-			border.BottomRight = "│"
-		} else if isLast && !isActive {
-			border.BottomRight = "┤"
-		}
-
-		style = style.Border(border)
 		renderedTabs = append(renderedTabs, style.Render(t))
 	}
 
 	row := lipgloss.JoinHorizontal(lipgloss.Top, renderedTabs...)
-
-	lipgloss.JoinVertical(lipgloss.Left, row, r.viewport.View())
+	centered := lipgloss.PlaceHorizontal(r.width-2, lipgloss.Center, row,
+		lipgloss.WithWhitespaceChars(s.border.Top),
+		lipgloss.WithWhitespaceStyle(borderCharStyle))
+	top := borderCharStyle.Render("╭") + centered + borderCharStyle.Render("╮")
 
 	styledResultSet := resultSetStyle.BorderForeground(tableBorder).Width(r.width).Height(r.height).UnsetBorderTop()
 
-	doc.WriteString(row)
+	doc := strings.Builder{}
+	doc.WriteString(top)
 	doc.WriteString("\n")
 	doc.WriteString(styledResultSet.Render(r.viewport.View()))
 	return tea.NewView(doc.String())
@@ -406,17 +381,6 @@ func (r *ResultSet) updateMetadataOnChange(metadata *client.Metadata, isTable bo
 			}
 		}
 	}
-}
-
-// tabBorderWithBottom function is used to define the tab borders.
-// Borders changes whether the tabs is inacative or inactive.
-// Active tab misses the bottom border.
-func tabBorderWithBottom(left, middle, right string) lipgloss.Border {
-	border := lipgloss.RoundedBorder()
-	border.BottomLeft = left
-	border.Bottom = middle
-	border.BottomRight = right
-	return border
 }
 
 func newTablePanel(height, width int) *TablePanel {

--- a/pkg/bubbletui/resultset.go
+++ b/pkg/bubbletui/resultset.go
@@ -298,7 +298,7 @@ func (r ResultSet) View() tea.View {
 			style = s.activeTab
 		}
 		if i > 0 {
-			renderedTabs = append(renderedTabs, "─")
+			renderedTabs = append(renderedTabs, lipgloss.NewStyle().Foreground(tableBorder).Render("─"))
 		}
 		renderedTabs = append(renderedTabs, style.Render(t))
 	}

--- a/pkg/bubbletui/resultset.go
+++ b/pkg/bubbletui/resultset.go
@@ -308,11 +308,7 @@ func (r ResultSet) View() tea.View {
 
 	tabsWidth := lipgloss.Width(strings.Join(renderedTabs, ""))
 
-	availableWidth := r.width - 2 - tabsWidth
-	if availableWidth < 0 {
-		availableWidth = 0
-	}
-	separatorWidth := ((availableWidth / (len(r.tabs))) / 2)
+	separatorWidth := (max(availableWidth, 0) / len(r.tabs)) / 2
 
 	separator := strings.Repeat(lipgloss.NewStyle().Foreground(tableBorder).Render("─"), separatorWidth)
 	tabs := strings.Join(renderedTabs, separator)

--- a/pkg/bubbletui/resultset.go
+++ b/pkg/bubbletui/resultset.go
@@ -306,9 +306,7 @@ func (r ResultSet) View() tea.View {
 		renderedTabs = append(renderedTabs, style.Render(t))
 	}
 
-	tabsWidth := lipgloss.Width(strings.Join(renderedTabs, ""))
-
-	separatorWidth := (max(availableWidth, 0) / len(r.tabs)) / 2
+	separatorWidth := (max(r.width, 0) / len(r.tabs)) / 2
 
 	separator := strings.Repeat(lipgloss.NewStyle().Foreground(tableBorder).Render("─"), separatorWidth)
 	tabs := strings.Join(renderedTabs, separator)

--- a/pkg/bubbletui/resultset.go
+++ b/pkg/bubbletui/resultset.go
@@ -312,7 +312,7 @@ func (r ResultSet) View() tea.View {
 	if availableWidth < 0 {
 		availableWidth = 0
 	}
-	separatorWidth := ((availableWidth / (len(r.tabs) - 1)) / 2)
+	separatorWidth := ((availableWidth / (len(r.tabs))) / 2)
 
 	separator := strings.Repeat(lipgloss.NewStyle().Foreground(tableBorder).Render("─"), separatorWidth)
 	tabs := strings.Join(renderedTabs, separator)


### PR DESCRIPTION
# Pull Request Template

## Description

The current tabs use more space and looks with border colors without focus
<img width="1280" height="123" alt="image" src="https://github.com/user-attachments/assets/bc43c82c-2b40-4a2d-b36f-aa7bbabb9483" />

We propose to use tabs like this:

Focus
<img width="723" height="142" alt="image" src="https://github.com/user-attachments/assets/8b2c6f11-8e45-4e95-98f5-2b19b2e8ff66" />

Without focus
<img width="741" height="201" alt="image" src="https://github.com/user-attachments/assets/e642a96b-e896-4702-8724-da0f3cf8456a" />


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manually.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
