### PR TITLE
Fix metadata queries by fetching data from pg_catalog

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -383,7 +383,7 @@ func (suite *ClientTestSuite) TestMetadata() {
 
 	switch suite.driver {
 	case drivers.Postgres:
-		suite.Len(m.Structure.Columns, 8)
+		suite.Len(m.Structure.Columns, 5)
 	case drivers.MySQL:
 		suite.Len(m.Structure.Columns, 6)
 	default:

--- a/pkg/client/postgres.go
+++ b/pkg/client/postgres.go
@@ -36,31 +36,24 @@ func (p *postgres) TableStructure(table TableRef) (string, []any, error) {
 	psql := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
 	query, args, err := psql.Select(
-		"c.column_name",
-		"c.is_nullable",
-		"c.data_type",
-		"c.character_maximum_length",
-		"c.numeric_precision",
-		"c.numeric_scale",
-		"c.ordinal_position",
-		"tc.constraint_type AS pkey",
+		"a.attname AS column_name",
+		"NOT a.attnotnull AS is_nullable",
+		"pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type",
+		"a.attnum AS ordinal_position",
+		"COALESCE(i.indisprimary, false) AS pkey",
 	).
-		From("information_schema.columns AS c").
-		LeftJoin(
-			`information_schema.constraint_column_usage AS ccu
-					ON c.table_schema = ccu.table_schema
-						AND c.table_name = ccu.table_name
-						AND c.column_name = ccu.column_name`,
-		).
-		LeftJoin(
-			`information_schema.table_constraints AS tc
-					ON ccu.constraint_schema = tc.constraint_schema
-						AND ccu.constraint_name = tc.constraint_name`,
-		).
+		From("pg_catalog.pg_attribute a").
+		Join("pg_catalog.pg_class c ON a.attrelid = c.oid").
+		Join("pg_catalog.pg_namespace n ON c.relnamespace = n.oid").
+		LeftJoin(`pg_catalog.pg_index i ON c.oid = i.indrelid 
+                AND a.attnum = ANY(i.indkey) 
+                AND i.indisprimary`).
 		Where(
 			sq.And{
-				sq.Eq{"c.table_schema": table.Schema},
-				sq.Eq{"c.table_name": table.Name},
+				sq.Eq{"n.nspname": table.Schema},
+				sq.Eq{"c.relname": table.Name},
+				sq.Gt{"a.attnum": 0},
+				sq.Expr("NOT a.attisdropped"),
 			},
 		).
 		ToSql()
@@ -70,22 +63,23 @@ func (p *postgres) TableStructure(table TableRef) (string, []any, error) {
 
 // Constraints returns all the constraints of a given table, under a schema.
 func (p *postgres) Constraints(table TableRef) (string, []any, error) {
-	var (
-		query sq.SelectBuilder
-		sql   string
-	)
-
-	query = sq.Select(
-		`tc.constraint_name`,
-		`tc.table_name`,
-		`tc.constraint_type`,
+	sql, args, err := sq.Select(
+		"con.conname AS constraint_name",
+		"c.relname AS table_name",
+		"con.contype AS constraint_type",
+		"pg_catalog.pg_get_constraintdef(con.oid) AS constraint_definition",
 	).
-		From("information_schema.table_constraints AS tc").
-		Where(sq.Eq{"tc.table_name": table.Name}).
-		Where(sq.Eq{"tc.table_schema": table.Schema}).
-		PlaceholderFormat(sq.Dollar)
-
-	sql, args, err := query.ToSql()
+		From("pg_catalog.pg_constraint con").
+		Join("pg_catalog.pg_class c ON con.conrelid = c.oid").
+		Join("pg_catalog.pg_namespace n ON c.relnamespace = n.oid").
+		Where(
+			sq.And{
+				sq.Eq{"n.nspname": table.Schema},
+				sq.Eq{"c.relname": table.Name},
+			},
+		).
+		PlaceholderFormat(sq.Dollar).
+		ToSql()
 	if err != nil {
 		return "", nil, err
 	}
@@ -94,19 +88,27 @@ func (p *postgres) Constraints(table TableRef) (string, []any, error) {
 
 // Indexes returns the indexes of a table, under a schema.
 func (p *postgres) Indexes(table TableRef) (string, []any, error) {
-	query := sq.Select("*").
-		From("pg_indexes").
-		Where(sq.And{
-			sq.Eq{"schemaname": table.Schema},
-			sq.Eq{"tablename": table.Name},
-		}).
-		PlaceholderFormat(sq.Dollar)
-
-	sql, args, err := query.ToSql()
-	if err != nil {
-		return "", nil, err
-	}
-
+	sql, args, err := sq.Select(
+		"n.nspname as schema_name",
+		"ix.relname AS index_name",
+		"i.indisunique AS is_unique",
+		"i.indisprimary AS is_primary",
+		"a.attname AS column_name",
+		"pg_catalog.pg_get_indexdef(i.indexrelid) AS index_definition",
+	).
+		From("pg_catalog.pg_class t").
+		Join("pg_catalog.pg_index i ON t.oid = i.indrelid").
+		Join("pg_catalog.pg_class ix ON i.indexrelid = ix.oid").
+		Join("pg_catalog.pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(i.indkey)").
+		Join("pg_catalog.pg_namespace n ON t.relnamespace = n.oid").
+		Where(
+			sq.And{
+				sq.Eq{"n.nspname": table.Schema},
+				sq.Eq{"t.relname": table.Name},
+			},
+		).
+		PlaceholderFormat(sq.Dollar).
+		ToSql()
 	return sql, args, err
 }
 
@@ -213,7 +215,6 @@ func (p *postgres) fetchSchemas(_ context.Context, parentID string) ([]*DBNode, 
 			return nil, err
 		}
 		schemas = append(schemas, &DBNode{
-
 			ID:         fmt.Sprintf("%s.s:%s", parentID, name),
 			Name:       name,
 			EntityName: name,


### PR DESCRIPTION
# Fix metadata queries by fetching data from pg_catalog

## Description

@rkgarcia reported duplicated columns in the result set from the `TableStructure` method. That is because I used to fetch data from `information_schema.constraint_column_usage`. The `constraint_column_usage` view identifies the columns that a constraint targets, not just the columns where it is defined.

To fix this, we should use `information_schema.key_column_usage`, which explicitly maps constraints to the columns in the table defining them. To remove duplicates, we should check if `constraint_type` is a `PRIMARY_KEY`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Hit listed databases and open the Columns tab.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
