### PR TITLE
fix(keymap): Fix go top and bottom keymap

### DIFF
--- a/.dblab.yaml
+++ b/.dblab.yaml
@@ -94,8 +94,8 @@ keybindings:
     execute-query: 'ctrl+e'
     execute-single-query: 'ctrl+r'
   sidebar:
-    go-top: 'ctrl+k'
-    go-bottom: 'ctrl+j'
+    go-top: 'alt+k'
+    go-bottom: 'alt+j'
   resultset:
     next-tab: 'tab'
     prev-tab: 'shift+tab'

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Key bindings used to be partly flat: `next-tab`, `prev-tab`, `page-top`, `page-b
 
 The old top-level fields are no longer read: if your config still sets them, those bindings silently fall back to their defaults. Two things to be aware of while migrating:
 
-- The sidebar's jump-to-top / jump-to-bottom defaults changed from <kbd>g</kbd> / <kbd>G</kbd> to <kbd>shift+k</kbd> / <kbd>shift+j</kbd>, which leaves <kbd>g</kbd> / <kbd>G</kbd> free for the editor and the result set.
+- The sidebar's jump-to-top / jump-to-bottom defaults changed from <kbd>g</kbd> / <kbd>G</kbd> to <kbd>alt+k</kbd> / <kbd>alt+j</kbd>, which leaves <kbd>g</kbd> / <kbd>G</kbd> free for the editor and the result set.
 - The editor gained `line-start`, `line-end`, `go-top` and `go-bottom`. These motions already worked, but were hardcoded to <kbd>0</kbd>, <kbd>$</kbd>, <kbd>g</kbd> and <kbd>G</kbd>; they are now configurable.
 
 The previously deprecated top-level `execute-query` field is gone as well — use `execute-query` under `keybindings.editor`.
@@ -435,8 +435,8 @@ keybindings:
     execute-single-query: 'ctrl+r'
   # the database tree on the left
   sidebar:
-    go-top: 'shift+k'
-    go-bottom: 'shift+j'
+    go-top: 'alt+k'
+    go-bottom: 'alt+j'
   # the result set panel and its metadata tabs
   resultset:
     next-tab: 'tab'
@@ -522,7 +522,7 @@ dblab connects to a single database (the `--db` flag is mandatory) and displays 
 
 <img src="screenshots/tree-view.png" />
 
-Navigate the tree with <kbd>Up</kbd> and <kbd>Down</kbd> (or <kbd>k</kbd> and <kbd>j</kbd>), and press <kbd>Enter</kbd> on a table to load its rows into the result set panel. Jump straight to the first or last visible node with <kbd>shift+k</kbd> and <kbd>shift+j</kbd> (`keybindings.sidebar.go-top` and `keybindings.sidebar.go-bottom`), and scroll the tree sideways with <kbd>h</kbd> and <kbd>l</kbd> when a name is wider than the panel.
+Navigate the tree with <kbd>Up</kbd> and <kbd>Down</kbd> (or <kbd>k</kbd> and <kbd>j</kbd>), and press <kbd>Enter</kbd> on a table to load its rows into the result set panel. Jump straight to the first or last visible node with <kbd>alt+k</kbd> and <kbd>alt+j</kbd> (`keybindings.sidebar.go-top` and `keybindings.sidebar.go-bottom`), and scroll the tree sideways with <kbd>h</kbd> and <kbd>l</kbd> when a name is wider than the panel.
 
 Press <kbd>/</kbd> to search the tree by name and <kbd>Esc</kbd> to leave the search. While a search is active every character you type — including <kbd>h</kbd> and <kbd>l</kbd> — goes to the search box instead of scrolling the tree.
 
@@ -644,8 +644,8 @@ These are the defaults; see [Key bindings configuration](#key-bindings-configura
 |-----|-------------|--------------|
 | <kbd>Arrow Up</kbd> / <kbd>k</kbd> | Move up the tree | — |
 | <kbd>Arrow Down</kbd> / <kbd>j</kbd> | Move down the tree | — |
-| <kbd>shift+k</kbd> | Jump to the first visible node | `sidebar.go-top` |
-| <kbd>shift+j</kbd> | Jump to the last visible node | `sidebar.go-bottom` |
+| <kbd>alt+k</kbd> | Jump to the first visible node | `sidebar.go-top` |
+| <kbd>alt+j</kbd> | Jump to the last visible node | `sidebar.go-bottom` |
 | <kbd>h</kbd> / <kbd>l</kbd> | Scroll the tree left / right | — |
 | <kbd>/</kbd> | Search the tree by name | — |
 | <kbd>Esc</kbd> | Leave the search | — |

--- a/docs/tutorials/config-file.md
+++ b/docs/tutorials/config-file.md
@@ -127,8 +127,8 @@ keybindings:
     execute-query: 'ctrl+e'
     execute-single-query: 'ctrl+r'
   sidebar:
-    go-top: 'shift+k'
-    go-bottom: 'shift+j'
+    go-top: 'alt+k'
+    go-bottom: 'alt+j'
   resultset:
     next-tab: 'tab'
     prev-tab: 'shift+tab'

--- a/docs/tutorials/navigation.md
+++ b/docs/tutorials/navigation.md
@@ -19,7 +19,7 @@ Focus the sidebar and move through the tree with the <kbd>Arrow Up</kbd> and <kb
 
 ![dblab](https://raw.githubusercontent.com/danvergara/dblab/main/assets/tutorials/images/left-menu.png){ width="400" : .center }
 
-On a long catalog you don't have to walk the whole tree: <kbd>shift+k</kbd> and <kbd>shift+j</kbd> jump to the first and last visible node, and <kbd>/</kbd> starts a search by name — type part of the table you're after and press <kbd>Esc</kbd> when you're done searching. If a name is wider than the panel, <kbd>h</kbd> and <kbd>l</kbd> scroll the tree sideways.
+On a long catalog you don't have to walk the whole tree: <kbd>alt+k</kbd> and <kbd>alt+j</kbd> jump to the first and last visible node, and <kbd>/</kbd> starts a search by name — type part of the table you're after and press <kbd>Esc</kbd> when you're done searching. If a name is wider than the panel, <kbd>h</kbd> and <kbd>l</kbd> scroll the tree sideways.
 
 Once the table you want is highlighted, press <kbd>Enter</kbd> to select it. dblab loads its rows into the result set panel and fills in the metadata tabs described below.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -281,7 +281,7 @@ Key bindings used to be partly flat: `next-tab`, `prev-tab`, `page-top`, `page-b
 
 The old top-level fields are no longer read: if your config still sets them, those bindings silently fall back to their defaults. Two things to be aware of while migrating:
 
-- The sidebar's jump-to-top / jump-to-bottom defaults changed from <kbd>g</kbd> / <kbd>G</kbd> to <kbd>shift+k</kbd> / <kbd>shift+j</kbd>, which leaves <kbd>g</kbd> / <kbd>G</kbd> free for the editor and the result set.
+- The sidebar's jump-to-top / jump-to-bottom defaults changed from <kbd>g</kbd> / <kbd>G</kbd> to <kbd>alt+k</kbd> / <kbd>alt+j</kbd>, which leaves <kbd>g</kbd> / <kbd>G</kbd> free for the editor and the result set.
 - The editor gained `line-start`, `line-end`, `go-top` and `go-bottom`. These motions already worked, but were hardcoded to <kbd>0</kbd>, <kbd>$</kbd>, <kbd>g</kbd> and <kbd>G</kbd>; they are now configurable.
 
 The previously deprecated top-level `execute-query` field is gone as well — use `execute-query` under `keybindings.editor`.
@@ -385,8 +385,8 @@ keybindings:
     execute-single-query: 'ctrl+r'
   # the database tree on the left
   sidebar:
-    go-top: 'shift+k'
-    go-bottom: 'shift+j'
+    go-top: 'alt+k'
+    go-bottom: 'alt+j'
   # the result set panel and its metadata tabs
   resultset:
     next-tab: 'tab'
@@ -476,7 +476,7 @@ dblab connects to a single database (the `--db` flag is mandatory) and displays 
 
 ![dblab](https://raw.githubusercontent.com/danvergara/dblab/main/screenshots/tree-view.png){ width="700" : .center }
 
-Navigate the tree with <kbd>Up</kbd> and <kbd>Down</kbd> (or <kbd>k</kbd> and <kbd>j</kbd>), and press <kbd>Enter</kbd> on a table to load its rows into the result set panel. Jump straight to the first or last visible node with <kbd>shift+k</kbd> and <kbd>shift+j</kbd> (`keybindings.sidebar.go-top` and `keybindings.sidebar.go-bottom`), and scroll the tree sideways with <kbd>h</kbd> and <kbd>l</kbd> when a name is wider than the panel.
+Navigate the tree with <kbd>Up</kbd> and <kbd>Down</kbd> (or <kbd>k</kbd> and <kbd>j</kbd>), and press <kbd>Enter</kbd> on a table to load its rows into the result set panel. Jump straight to the first or last visible node with <kbd>alt+k</kbd> and <kbd>alt+j</kbd> (`keybindings.sidebar.go-top` and `keybindings.sidebar.go-bottom`), and scroll the tree sideways with <kbd>h</kbd> and <kbd>l</kbd> when a name is wider than the panel.
 
 Press <kbd>/</kbd> to search the tree by name and <kbd>Esc</kbd> to leave the search. While a search is active every character you type — including <kbd>h</kbd> and <kbd>l</kbd> — goes to the search box instead of scrolling the tree.
 
@@ -599,8 +599,8 @@ These are the defaults; see [Key bindings configuration](#key-bindings-configura
 |-----|-------------|--------------|
 | <kbd>Arrow Up</kbd> / <kbd>k</kbd> | Move up the tree | — |
 | <kbd>Arrow Down</kbd> / <kbd>j</kbd> | Move down the tree | — |
-| <kbd>shift+k</kbd> | Jump to the first visible node | `sidebar.go-top` |
-| <kbd>shift+j</kbd> | Jump to the last visible node | `sidebar.go-bottom` |
+| <kbd>alt+k</kbd> | Jump to the first visible node | `sidebar.go-top` |
+| <kbd>alt+j</kbd> | Jump to the last visible node | `sidebar.go-bottom` |
 | <kbd>h</kbd> / <kbd>l</kbd> | Scroll the tree left / right | — |
 | <kbd>/</kbd> | Search the tree by name | — |
 | <kbd>Esc</kbd> | Leave the search | — |

--- a/pkg/bubbletui/keys/keys.go
+++ b/pkg/bubbletui/keys/keys.go
@@ -210,12 +210,12 @@ type SidebarKeyMap struct {
 func DefaultSidebarKeyMap() SidebarKeyMap {
 	return SidebarKeyMap{
 		GoToTop: key.NewBinding(
-			key.WithKeys("shift+k"),
-			key.WithHelp("shift+k", "go to top (sidebar database graph)"),
+			key.WithKeys("alt+k"),
+			key.WithHelp("alt+k", "go to top (sidebar database graph)"),
 		),
 		GoToBottom: key.NewBinding(
-			key.WithKeys("shift+j"),
-			key.WithHelp("shift+j", "go to bottom (sidebar database graph)"),
+			key.WithKeys("alt+j"),
+			key.WithHelp("alt+j", "go to bottom (sidebar database graph)"),
 		),
 	}
 }

--- a/pkg/config/.dblab.yaml
+++ b/pkg/config/.dblab.yaml
@@ -88,7 +88,7 @@ keybindings:
     execute-single-query: 'ctrl+r'
   sidebar:
     go-top: 'foo'
-    go-bottom: 'shift+j'
+    go-bottom: 'J'
   resultset:
     next-tab: 'bar'
     prev-tab: 'shift+tab'

--- a/pkg/config/.dblab.yaml
+++ b/pkg/config/.dblab.yaml
@@ -88,7 +88,7 @@ keybindings:
     execute-single-query: 'ctrl+r'
   sidebar:
     go-top: 'foo'
-    go-bottom: 'J'
+    go-bottom: 'alt+j'
   resultset:
     next-tab: 'bar'
     prev-tab: 'shift+tab'

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -111,8 +111,8 @@ type EditorKeyMap struct {
 }
 
 type SidebarKeyMap struct {
-	GoToTop    string `fig:"go-top" default:"shift+k"`
-	GoToBottom string `fig:"go-bottom" default:"shift+j"`
+	GoToTop    string `fig:"go-top" default:"alt+k"`
+	GoToBottom string `fig:"go-bottom" default:"alt+j"`
 }
 
 type ResultSetKeyMap struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -207,8 +207,8 @@ func TestSetupKeybindings(t *testing.T) {
 	assert.Contains(t, km.Editor.ExecuteSingleQuery, "ctrl+r")
 
 	// Sidebar.
-	assert.Contains(t, km.Sidebar.GoToTop, "foo") // should be shift+k, but it tests the value comes from the config file
-	assert.Contains(t, km.Sidebar.GoToBottom, "shift+j")
+	assert.Contains(t, km.Sidebar.GoToTop, "foo") // should be alt+k, but it tests the value comes from the config file
+	assert.Contains(t, km.Sidebar.GoToBottom, "alt+j")
 
 	// Result set.
 	assert.Contains(t, km.ResultSet.NextTab, "bar") // should be tab, but it tests the value comes from the config file


### PR DESCRIPTION
## Description

I changed the keymap of the sidebar from `shift-j` and `shift-k` to `J` and `K`.

Fixes #360

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
