### PR TITLE
Test navigation in editor and sidebar

### DIFF
--- a/pkg/bubbletui/editor_test.go
+++ b/pkg/bubbletui/editor_test.go
@@ -44,7 +44,7 @@ func TestInsertQueriesAndExecute(t *testing.T) {
 	q, ok := cmd().(executeQueryMsg)
 	assert.True(t, ok, "Message should be a executeQueryMsg")
 	for i, expectedQuery := range queries {
-		assert.Equal(t, q.queriesToRun[i],expectedQuery)
+		assert.Equal(t, q.queriesToRun[i], expectedQuery)
 	}
 }
 

--- a/pkg/bubbletui/editor_test.go
+++ b/pkg/bubbletui/editor_test.go
@@ -1,7 +1,13 @@
 package bubbletui
 
 import (
+	"errors"
+	"strings"
 	"testing"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"github.com/danvergara/dblab/pkg/bubbletui/keys"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -27,4 +33,56 @@ func TestQueryAtCursor(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestInsertQueriesAndExecute(t *testing.T) {
+	queries := []string{"SELECT * FROM users", "SELECT * FROM products", "SELECT * FROM logs"}
+	editor, err := createEditorWithQueries(queries)
+	assert.Nil(t, err)
+	// Run all queries
+	editor, cmd := editor.Update(tea.KeyPressMsg{Mod: tea.ModCtrl, Code: 'e'})
+	q, ok := cmd().(executeQueryMsg)
+	assert.True(t, ok, "Message should be a executeQueryMsg")
+	for i, expectedQuery := range queries {
+		assert.Equal(t, q.queriesToRun[i],expectedQuery)
+	}
+}
+
+func TestNavigateInEditorAndRunSingleQuery(t *testing.T) {
+	queries := []string{"SELECT * FROM users", "SELECT * FROM products", "SELECT * FROM logs"}
+	editor, err := createEditorWithQueries(queries)
+	assert.Nil(t, err)
+	assert.Equal(t, editor.editor.Line(), 2, "Editor not in expected line")
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	assert.Equal(t, editor.editor.Line(), 1, "Editor didn't go up")
+	// Run second query
+	editor, cmd := editor.Update(tea.KeyPressMsg{Mod: tea.ModCtrl, Code: 'r'})
+	q, ok := cmd().(executeQueryMsg)
+	assert.True(t, ok, "Message should be a executeQueryMsg")
+	assert.Len(t, q.queriesToRun, 1, "Should execute a single query.")
+	assert.Equal(t, q.queriesToRun[0], queries[1], "Should run the second query")
+}
+
+func createEditorWithQueries(queries []string) (Editor, error) {
+	qs := strings.Join(queries, ";\n")
+	km := keys.DefaultEditorKeyMap()
+	km.ExecuteQuery = key.NewBinding(
+		key.WithKeys("ctrl+e"),
+		key.WithHelp("ctrl+e", "execute queries in the editor"),
+	)
+	km.ExecuteSingleQuery = key.NewBinding(
+		key.WithKeys("ctrl+r"),
+		key.WithHelp("ctrl+r", "execute queries in the editor"),
+	)
+	editor := NewEditor(km)
+	editor, cmd := editor.Update(tea.KeyPressMsg{Text: "i", Code: 'i'})
+	_, ok := cmd().(modeChangeMsg)
+	if !ok {
+		return Editor{}, errors.New("Cannot change editor mode")
+	}
+	editor, _ = editor.Update(tea.PasteMsg{Content: qs})
+	if editor.editor.Value() != qs {
+		return Editor{}, errors.New("Editor content doesn't match: " + editor.editor.Value())
+	}
+	return editor, nil
 }

--- a/pkg/bubbletui/sidebar_test.go
+++ b/pkg/bubbletui/sidebar_test.go
@@ -1,0 +1,101 @@
+package bubbletui
+
+import (
+	"context"
+	"testing"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"github.com/danvergara/dblab/pkg/bubbletui/keys"
+	"github.com/danvergara/dblab/pkg/client"
+	"github.com/danvergara/dblab/pkg/command"
+	"github.com/danvergara/dblab/pkg/drivers"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNavigateSidebar(t *testing.T) {
+	ctx := context.Background()
+	km := SidebarKeyMapTest()
+	client, err := NewTestClient()
+	assert.Nil(t, err)
+	s, err := NewSidebarViewport(ctx, client, km)
+	assert.Nil(t, err)
+	updates := []struct {
+		Key          tea.KeyPressMsg
+		ExpectedNode string
+	}{
+		{tea.KeyPressMsg{Code: tea.KeyEnter}, ":memory:"}, // Press enter to load table tree
+		{tea.KeyPressMsg{Mod: tea.ModCtrl, Code: 'b'}, "actor_name - v"},
+		{tea.KeyPressMsg{Mod: tea.ModCtrl, Code: 't'}, ":memory:"},
+		{tea.KeyPressMsg{Code: tea.KeyDown}, "actor - t"},
+		{tea.KeyPressMsg{Code: tea.KeyDown}, "country - t"},
+	}
+	for _, update := range updates {
+		s, _ = s.Update(update.Key)
+		assert.Equal(t, s.dbTree.GetFocusedNode().Name(), update.ExpectedNode)
+	}
+}
+
+func TestSelectSidebarTable(t *testing.T) {
+	ctx := context.Background()
+	km := SidebarKeyMapTest()
+	client, err := NewTestClient()
+	assert.Nil(t, err)
+	s, err := NewSidebarViewport(ctx, client, km)
+	assert.Nil(t, err)
+	assert.Equal(t, s.dbTree.GetFocusedNode().Name(), ":memory:", "The database name is unexpected")
+
+	// Navidate to first table
+	s, _ = s.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	s, _ = s.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+
+	// Select first table
+	s, cmd := s.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	tableMsg, ok := cmd().(selectTableMsg)
+	assert.True(t, ok, "Message should be a selectTableMsg")
+	assert.Equal(t, tableMsg.Table, "actor", "Should emit a query to the first table")
+
+	// Navigate to last view
+	s, _ = s.Update(tea.KeyPressMsg{Mod: tea.ModCtrl, Code: 'b'})
+	s, cmd = s.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	viewMsg, ok := cmd().(selectViewMsg)
+	assert.True(t, ok, "Message should be a selectViewMsg")
+	assert.Equal(t, viewMsg.View, "actor_name", "Should emit a query to the last view")
+}
+
+func NewTestClient() (*client.Client, error) {
+	var opts command.Options
+	opts.Driver = drivers.SQLite
+	opts.Host = ":memory:"
+	opts.DBName = ":memory:"
+	c, err := client.New(opts)
+	if err != nil {
+		return nil, err
+	}
+	stmts := []string{
+		"CREATE TABLE actor (actor_id INTEGER NOT NULL, first_name VARCHAR(45) NOT NULL, last_name VARCHAR(45) NOT NULL, PRIMARY KEY (actor_id));",
+		"CREATE TABLE country (country_id INTEGER NOT NULL, country VARCHAR(50) NOT NULL, last_update TIMESTAMP, PRIMARY KEY (country_id));",
+		"CREATE VIEW actor_name (actor_id, fullname) AS SELECT actor_id, concat(first_name, ' ', last_name) as fullname FROM actor;",
+	}
+	for _, stmt := range stmts {
+		_, err = c.DB().Exec(stmt)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c, nil
+}
+
+func SidebarKeyMapTest() keys.SidebarKeyMap {
+	return keys.SidebarKeyMap{
+		GoToTop: key.NewBinding(
+			key.WithKeys("ctrl+t"),
+			key.WithHelp("ctrl+t", "go to top (sidebar database graph)"),
+		),
+		GoToBottom: key.NewBinding(
+			key.WithKeys("ctrl+b"),
+			key.WithHelp("ctrl+b", "go to bottom (sidebar database graph)"),
+		),
+	}
+}


### PR DESCRIPTION
## Description

As I said in the issue #327, I think there is a lack of unit tests specially in the TUI models, so I added new unit tests in the editor and sidebar models. Besides, to test the latter model, I added a function to create a sqlite client in memory, It runs really fast and allow to navigate in the sidebar tree without the need of mocking anything.

## Type of change

- [x] Add test suite

## How Has This Been Tested?

I run the old tests manually and the new ones.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
