### PR TITLE
Current Schema

### DIFF
--- a/.dblab.yaml
+++ b/.dblab.yaml
@@ -75,6 +75,7 @@ keybindings:
   help: '?'
   quit: 'ctrl+c'
   history: 'alt+h'
+  schemas: 'ctrl+s'
   navigation:
     up: 'ctrl+k'
     down: 'ctrl+j'

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ __Interactive client for PostgreSQL, MySQL, SQLite3, Oracle and SQL Server.__
 - [Navigation](#navigation)
     - [Panels and the sidebar tree](#panels-and-the-sidebar-tree)
     - [Result sets](#result-sets)
+    - [Active schema](#active-schema)
 - [Query editor](#query-editor)
     - [Modes](#modes)
     - [Editing and motions](#editing-and-motions)
@@ -63,6 +64,7 @@ application to work with local or remote PostgreSQL/MySQL/SQLite3/Oracle/SQL Ser
 - Connection profiles with secure credential storage in the OS keyring.
 - Query history: executed queries are persisted across sessions and can be browsed/re-used via a filterable list.
 - Read-only mode: use `--readonly` to prevent accidental writes by forcing the database session into read-only mode (supported for PostgreSQL, MySQL, SQLite, Oracle, and SQL Server).
+- Schema switching: press <kbd>ctrl+s</kbd> to pick the active schema from a filterable list without restarting the app (PostgreSQL and Oracle); the active schema is always shown in the status bar.
 - Built-in help modal: press <kbd>?</kbd> to display a help overlay showing all available key bindings; press <kbd>Esc</kbd> to dismiss it.
 - Full-screen mode: press <kbd>alt+f</kbd> to expand the focused query editor or result set panel to fill the terminal; press <kbd>Esc</kbd> to exit.
 - Per-panel key bindings: the query editor, the sidebar tree, the result set panel and the panel navigation each have their own section in `.dblab.yaml`, so every panel can be rebound independently.
@@ -183,6 +185,8 @@ $ dblab --url postgres://user:password@host:port/database?sslmode=[mode] --schem
 $ dblab --host localhost --user user2 --db FREEPDB1 --pass password --port 1521 --driver oracle --limit 50 --schema user1
 $ dblab --url 'oracle://user2:password@localhost:1521/FREEPDB1' --schema user1
 ```
+
+Whether you pass `--schema` or not, the schema the session is currently using is shown in the status bar and can be changed at any time with <kbd>ctrl+s</kbd> — see [Active schema](#active-schema).
 
 You can use the `--readonly` flag to open a connection in read-only mode. This prevents any write operations (INSERT, UPDATE, DELETE, etc.) from being executed, which is useful when you want to safely browse a production database. The same can be achieved via the configuration file by setting `readonly: true` on a database profile (see [Configuration](#configuration)).
 
@@ -309,7 +313,7 @@ Bindings are grouped by the part of the UI they belong to, so every panel can be
 
 | Section | What it controls |
 | --------- | ------------------ |
-| `keybindings` (top level) | `help`, `quit`, `history` and `fullscreen`, which are global |
+| `keybindings` (top level) | `help`, `quit`, `history`, `fullscreen` and `schemas`, which are global |
 | `keybindings.navigation` | moving focus between the three panels |
 | `keybindings.editor` | the Vim-style query editor: cursor motion in normal mode, mode switching, and query execution |
 | `keybindings.sidebar` | jumping to the top / bottom of the sidebar tree |
@@ -415,6 +419,8 @@ keybindings:
   quit: 'ctrl+c'
   history: 'alt+h'
   fullscreen: 'alt+f'
+  # opens the active schema picker (postgres and oracle only)
+  schemas: 'ctrl+s'
   # moving focus between the three panels
   navigation:
     up: 'ctrl+k'
@@ -545,6 +551,16 @@ Selecting a table populates the result set panel, which has one tab per view of 
 Move around a result set with the arrow keys or <kbd>h</kbd>/<kbd>j</kbd>/<kbd>k</kbd>/<kbd>l</kbd>. The selected cell is highlighted so you can see where you are; press <kbd>Enter</kbd> on a cell to copy its content.
 
 There are no pagination controls — they proved too slow to page through a table effectively. To work through a large table, write a `SELECT` with explicit `OFFSET` and `LIMIT` instead.
+
+### Active schema
+
+The right-hand side of the status bar shows the schema the session is currently using, as `active schema: <name>`. On startup that's whatever you passed to `--schema`, or the session default (`current_schema()` on PostgreSQL, `SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')` on Oracle) when the flag is omitted.
+
+Press <kbd>ctrl+s</kbd> (`schemas`) from any panel to open the schema picker, a filterable list of the schemas the connected user can see. Type to narrow the list, press <kbd>Enter</kbd> to make the highlighted schema the active one, or press <kbd>Esc</kbd> to close the picker without changing anything. Focus returns to the query editor either way.
+
+Switching the active schema changes the database session — `set search_path` on PostgreSQL, `ALTER SESSION SET CURRENT_SCHEMA` on Oracle — so unqualified table names in the queries you execute resolve against the new schema. The sidebar tree is left as it is: it keeps listing the schemas it was built with, and selecting a table there still reads that table's own schema, so browsing the catalog is unaffected.
+
+The picker is only available for PostgreSQL and Oracle, the two drivers where dblab tracks an active schema. On MySQL, SQLite and SQL Server <kbd>ctrl+s</kbd> does nothing and the status bar has no schema segment.
 
 ### Full-screen mode
 
@@ -682,8 +698,9 @@ Applies to all tabs of the result set panel.
 |-----|-------------|--------------|
 | <kbd>Alt+h</kbd>  | Open the query history view | `history` |
 | <kbd>Alt+f</kbd> | Expand the focused query editor or result set panel to full screen | `fullscreen` |
+| <kbd>Ctrl+s</kbd> | Open the schema picker to change the active schema (PostgreSQL and Oracle) | `schemas` |
 | <kbd>?</kbd> | Open the help modal showing all key bindings | `help` |
-| <kbd>Esc</kbd> | Dismiss the help modal or query history, exit full-screen mode (or return to normal mode in the query editor) | — |
+| <kbd>Esc</kbd> | Dismiss the help modal, the query history or the schema picker, exit full-screen mode (or return to normal mode in the query editor) | — |
 | <kbd>Ctrl+c</kbd> | Cancel running queries if any; otherwise quit the application | `quit` |
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ application to work with local or remote PostgreSQL/MySQL/SQLite3/Oracle/SQL Ser
 - Connection profiles with secure credential storage in the OS keyring.
 - Query history: executed queries are persisted across sessions and can be browsed/re-used via a filterable list.
 - Read-only mode: use `--readonly` to prevent accidental writes by forcing the database session into read-only mode (supported for PostgreSQL, MySQL, SQLite, Oracle, and SQL Server).
-- Schema switching: press <kbd>ctrl+s</kbd> to pick the active schema from a filterable list without restarting the app (PostgreSQL and Oracle); the active schema is always shown in the status bar.
+- Schema switching: press <kbd>ctrl+s</kbd> to pick the active schema from a filterable list without restarting the app (PostgreSQL and Oracle, when no schema was pinned at startup); the active schema is always shown in the status bar.
 - Built-in help modal: press <kbd>?</kbd> to display a help overlay showing all available key bindings; press <kbd>Esc</kbd> to dismiss it.
 - Full-screen mode: press <kbd>alt+f</kbd> to expand the focused query editor or result set panel to fill the terminal; press <kbd>Esc</kbd> to exit.
 - Per-panel key bindings: the query editor, the sidebar tree, the result set panel and the panel navigation each have their own section in `.dblab.yaml`, so every panel can be rebound independently.
@@ -186,7 +186,13 @@ $ dblab --host localhost --user user2 --db FREEPDB1 --pass password --port 1521 
 $ dblab --url 'oracle://user2:password@localhost:1521/FREEPDB1' --schema user1
 ```
 
-Whether you pass `--schema` or not, the schema the session is currently using is shown in the status bar and can be changed at any time with <kbd>ctrl+s</kbd> — see [Active schema](#active-schema).
+For PostgreSQL, the schema can also be set directly in the connection URL with the `search_path` query parameter, instead of passing `--schema` alongside it. Both forms are equivalent:
+
+```sh
+$ dblab --url 'postgres://user:password@localhost:5432/database?sslmode=disable&search_path=myschema'
+```
+
+The schema the session is currently using is shown in the status bar. If you don't pin a schema — no `--schema` flag, no `schema` field in the config file and no `search_path` in the URL — you can also change it at any time with <kbd>ctrl+s</kbd>; see [Active schema](#active-schema).
 
 You can use the `--readonly` flag to open a connection in read-only mode. This prevents any write operations (INSERT, UPDATE, DELETE, etc.) from being executed, which is useful when you want to safely browse a production database. The same can be achieved via the configuration file by setting `readonly: true` on a database profile (see [Configuration](#configuration)).
 
@@ -554,7 +560,9 @@ There are no pagination controls — they proved too slow to page through a tabl
 
 ### Active schema
 
-The right-hand side of the status bar shows the schema the session is currently using, as `active schema: <name>`. On startup that's whatever you passed to `--schema`, or the session default (`current_schema()` on PostgreSQL, `SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')` on Oracle) when the flag is omitted.
+The right-hand side of the status bar shows the schema the session is currently using, as `active schema: <name>`. On startup that's whatever schema you pinned — via `--schema`, the `schema` field in `.dblab.yaml`, or the `search_path` query parameter of a PostgreSQL connection URL — or the session default (`current_schema()` on PostgreSQL, `SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')` on Oracle) when you pinned none.
+
+If you pinned a schema, that's the schema for the whole session and the picker below is disabled: <kbd>ctrl+s</kbd> does nothing. Omit the schema to be able to switch it from the app.
 
 Press <kbd>ctrl+s</kbd> (`schemas`) from any panel to open the schema picker, a filterable list of the schemas the connected user can see. Type to narrow the list, press <kbd>Enter</kbd> to make the highlighted schema the active one, or press <kbd>Esc</kbd> to close the picker without changing anything. Focus returns to the query editor either way.
 
@@ -698,7 +706,7 @@ Applies to all tabs of the result set panel.
 |-----|-------------|--------------|
 | <kbd>Alt+h</kbd>  | Open the query history view | `history` |
 | <kbd>Alt+f</kbd> | Expand the focused query editor or result set panel to full screen | `fullscreen` |
-| <kbd>Ctrl+s</kbd> | Open the schema picker to change the active schema (PostgreSQL and Oracle) | `schemas` |
+| <kbd>Ctrl+s</kbd> | Open the schema picker to change the active schema (PostgreSQL and Oracle, when no schema was pinned at startup) | `schemas` |
 | <kbd>?</kbd> | Open the help modal showing all key bindings | `help` |
 | <kbd>Esc</kbd> | Dismiss the help modal, the query history or the schema picker, exit full-screen mode (or return to normal mode in the query editor) | — |
 | <kbd>Ctrl+c</kbd> | Cancel running queries if any; otherwise quit the application | `quit` |

--- a/docs/features.md
+++ b/docs/features.md
@@ -11,7 +11,7 @@ The key features are:
   * Connection profiles with secure credential storage in the OS keyring.  
   * Query history: executed queries are automatically saved and can be browsed or re-used from a searchable list.  
   * Read-only mode: use `--readonly` to prevent accidental writes by forcing the database session into read-only mode (PostgreSQL, MySQL, SQLite, Oracle, and SQL Server).
-  * Schema switching: press `ctrl+s` to pick the active schema from a filterable list without restarting the app (PostgreSQL and Oracle); the active schema is always shown in the status bar.
+  * Schema switching: press `ctrl+s` to pick the active schema from a filterable list without restarting the app (PostgreSQL and Oracle, when no schema was pinned at startup); the active schema is always shown in the status bar.
   * Built-in help modal: press `?` to display a help overlay showing all available key bindings; press `Esc` to dismiss it.
   * Full-screen mode: press `alt+f` to expand the focused query editor or result set panel to fill the terminal; press `Esc` to exit.
   * Per-panel key bindings: the query editor, the sidebar tree, the result set panel and the panel navigation each have their own section in `.dblab.yaml`, so every panel can be rebound independently.

--- a/docs/features.md
+++ b/docs/features.md
@@ -11,6 +11,7 @@ The key features are:
   * Connection profiles with secure credential storage in the OS keyring.  
   * Query history: executed queries are automatically saved and can be browsed or re-used from a searchable list.  
   * Read-only mode: use `--readonly` to prevent accidental writes by forcing the database session into read-only mode (PostgreSQL, MySQL, SQLite, Oracle, and SQL Server).
+  * Schema switching: press `ctrl+s` to pick the active schema from a filterable list without restarting the app (PostgreSQL and Oracle); the active schema is always shown in the status bar.
   * Built-in help modal: press `?` to display a help overlay showing all available key bindings; press `Esc` to dismiss it.
   * Full-screen mode: press `alt+f` to expand the focused query editor or result set panel to fill the terminal; press `Esc` to exit.
   * Per-panel key bindings: the query editor, the sidebar tree, the result set panel and the panel navigation each have their own section in `.dblab.yaml`, so every panel can be rebound independently.

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ application to work with local or remote PostgreSQL/MySQL/SQLite3/Oracle/SQL Ser
   * Connection profiles with secure credential storage in the OS keyring.  
   * Query history: executed queries are automatically saved and can be browsed or re-used from a searchable list.  
   * Read-only mode: use `--readonly` to prevent accidental writes by forcing the database session into read-only mode (PostgreSQL, MySQL, SQLite, Oracle, and SQL Server).  
-  * Schema switching: press `ctrl+s` to pick the active schema from a filterable list without restarting the app (PostgreSQL and Oracle); the active schema is always shown in the status bar.  
+  * Schema switching: press `ctrl+s` to pick the active schema from a filterable list without restarting the app (PostgreSQL and Oracle, when no schema was pinned at startup); the active schema is always shown in the status bar.  
   * Built-in help modal: press `?` to display a help overlay showing all available key bindings; press `Esc` to dismiss it.  
   * Full-screen mode: press `alt+f` to expand the focused query editor or result set panel to fill the terminal; press `Esc` to exit.  
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ application to work with local or remote PostgreSQL/MySQL/SQLite3/Oracle/SQL Ser
   * Connection profiles with secure credential storage in the OS keyring.  
   * Query history: executed queries are automatically saved and can be browsed or re-used from a searchable list.  
   * Read-only mode: use `--readonly` to prevent accidental writes by forcing the database session into read-only mode (PostgreSQL, MySQL, SQLite, Oracle, and SQL Server).  
+  * Schema switching: press `ctrl+s` to pick the active schema from a filterable list without restarting the app (PostgreSQL and Oracle); the active schema is always shown in the status bar.  
   * Built-in help modal: press `?` to display a help overlay showing all available key bindings; press `Esc` to dismiss it.  
   * Full-screen mode: press `alt+f` to expand the focused query editor or result set panel to fill the terminal; press `Esc` to exit.  
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -41,6 +41,12 @@ dblab --host localhost --user user2 --db FREEPDB1 --pass password --port 1521 --
 dblab --url 'oracle://user2:password@localhost:1521/FREEPDB1' --schema user1
 ```
 
+For PostgreSQL, the schema can also be set directly in the connection URL with the `search_path` query parameter, instead of passing `--schema` alongside it:
+
+```{ .sh .copy }
+dblab --url 'postgres://user:password@localhost:5432/database?sslmode=disable&search_path=myschema'
+```
+
 You can use the `--readonly` flag to open a connection in read-only mode, preventing any write operations:
 
 ```{ .sh .copy }

--- a/docs/tutorials/config-file.md
+++ b/docs/tutorials/config-file.md
@@ -30,6 +30,8 @@ limit: 50
 
 The `readonly` field is optional. When set to `true`, dblab forces the database session into read-only mode, preventing any write operations (INSERT, UPDATE, DELETE, etc.). This is useful when you want to safely browse a production database. The same can be achieved via the `--readonly` CLI flag.
 
+The `schema` field is optional too, and only applies to PostgreSQL and Oracle. It only sets the schema dblab starts with: once the app is running you can switch to any other schema you have access to with <kbd>ctrl+s</kbd>, and the schema in use is shown in the status bar. See [active schema](../usage.md#active-schema).
+
 Once created, we can launch `dblab` with the command:
 
 ```{ .sh .copy }
@@ -89,7 +91,7 @@ dblab --config --cfg-name "prod"
 
 Key bindings can also be configured through the `.dblab.yaml` file. There is a field called `keybindings` where you can customize the default shortcuts. By default, the keybindings are not loaded from the config file, so you need to use the `--keybindings` or `-k` flag to load them.
 
-The bindings are grouped by the part of the UI they belong to — `navigation` for moving focus between the three panels, `editor` for the Vim-style query editor, `sidebar` for the database tree, and `resultset` for the result set panel — plus `help`, `quit`, `history` and `fullscreen` at the top level. Because each panel has its own section, you can rebind, say, the editor's jump-to-top key without touching the sidebar's.
+The bindings are grouped by the part of the UI they belong to — `navigation` for moving focus between the three panels, `editor` for the Vim-style query editor, `sidebar` for the database tree, and `resultset` for the result set panel — plus `help`, `quit`, `history`, `fullscreen` and `schemas` at the top level. Because each panel has its own section, you can rebind, say, the editor's jump-to-top key without touching the sidebar's.
 
 Every field has a default, so you only need to list the ones you want to change. The following example spells out all of them:
 
@@ -109,6 +111,7 @@ keybindings:
   quit: 'ctrl+c'
   history: 'alt+h'
   fullscreen: 'alt+f'
+  schemas: 'ctrl+s'
   navigation:
     up: 'ctrl+k'
     down: 'ctrl+j'

--- a/docs/tutorials/config-file.md
+++ b/docs/tutorials/config-file.md
@@ -30,7 +30,7 @@ limit: 50
 
 The `readonly` field is optional. When set to `true`, dblab forces the database session into read-only mode, preventing any write operations (INSERT, UPDATE, DELETE, etc.). This is useful when you want to safely browse a production database. The same can be achieved via the `--readonly` CLI flag.
 
-The `schema` field is optional too, and only applies to PostgreSQL and Oracle. It only sets the schema dblab starts with: once the app is running you can switch to any other schema you have access to with <kbd>ctrl+s</kbd>, and the schema in use is shown in the status bar. See [active schema](../usage.md#active-schema).
+The `schema` field is optional too, and only applies to PostgreSQL and Oracle. Setting it pins the session to that schema: the schema in use is shown in the status bar, but the <kbd>ctrl+s</kbd> picker is disabled. Leave it out to be able to switch to any other schema you have access to while the app is running. See [active schema](../usage.md#active-schema).
 
 Once created, we can launch `dblab` with the command:
 

--- a/docs/tutorials/navigation.md
+++ b/docs/tutorials/navigation.md
@@ -88,6 +88,8 @@ The sidebar keeps showing the same tree — switching the active schema doesn't 
 
     This applies to PostgreSQL and Oracle only. MySQL, SQLite and SQL Server have no active schema in dblab, so <kbd>ctrl+s</kbd> does nothing there and the status bar shows no schema.
 
+    The picker also requires that you didn't pin a schema at startup. If you started dblab with `--schema`, with a `schema` field in the config file, or with `search_path=<schema>` in a PostgreSQL connection URL, that schema is fixed for the whole session and <kbd>ctrl+s</kbd> does nothing.
+
 ### Reusing a query you ran before
 
 ![dblab](https://raw.githubusercontent.com/danvergara/dblab/main/assets/tutorials/images/query-history.png){ width="400" : .center }

--- a/docs/tutorials/navigation.md
+++ b/docs/tutorials/navigation.md
@@ -76,11 +76,23 @@ Each statement gets its own result tab — "query #1", "query #2" and so on, thr
 
 While a batch is running, press <kbd>Ctrl+c</kbd> to cancel it; press <kbd>Ctrl+c</kbd> again to quit dblab.
 
+### Switching the active schema
+
+On PostgreSQL and Oracle, the right-hand side of the status bar tells you which schema the session is using — `active schema: public`, for instance. That's the schema unqualified table names in your queries resolve against, and you don't have to restart dblab to change it.
+
+Press <kbd>ctrl+s</kbd> to bring up the schema picker, which lists the schemas your user can see. Type to filter the list, press <kbd>Enter</kbd> on the one you want, and the status bar updates to show it; press <kbd>Esc</kbd> instead to close the picker and leave the schema alone. Either way you end up back in the query editor.
+
+The sidebar keeps showing the same tree — switching the active schema doesn't rebuild it, and picking a table there still reads that table's own schema. What changes is where an unqualified `SELECT` looks.
+
+!!! note
+
+    This applies to PostgreSQL and Oracle only. MySQL, SQLite and SQL Server have no active schema in dblab, so <kbd>ctrl+s</kbd> does nothing there and the status bar shows no schema.
+
 ### Reusing a query you ran before
 
 ![dblab](https://raw.githubusercontent.com/danvergara/dblab/main/assets/tutorials/images/query-history.png){ width="400" : .center }
 
-Every query you execute is saved to a local history file, so it survives across sessions. Press <kbd>F8</kbd> to open the history view, which lists your past queries newest-first. Type to filter the list, press <kbd>Enter</kbd> to load the highlighted query back into the editor, or press <kbd>Esc</kbd> to go back without picking anything.
+Every query you execute is saved to a local history file, so it survives across sessions. Press <kbd>alt+h</kbd> to open the history view, which lists your past queries newest-first. Type to filter the list, press <kbd>Enter</kbd> to load the highlighted query back into the editor, or press <kbd>Esc</kbd> to go back without picking anything.
 
 ### When you forget a key binding
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -131,7 +131,13 @@ dblab --host localhost --user user2 --db FREEPDB1 --pass password --port 1521 --
 dblab --url 'oracle://user2:password@localhost:1521/FREEPDB1' --schema user1
 ```
 
-Whether you pass `--schema` or not, the schema the session is currently using is shown in the status bar and can be changed at any time with <kbd>ctrl+s</kbd> — see [Active schema](#active-schema).
+For PostgreSQL, the schema can also be set directly in the connection URL with the `search_path` query parameter, instead of passing `--schema` alongside it. Both forms are equivalent:
+
+```{ .sh .copy }
+dblab --url 'postgres://user:password@localhost:5432/database?sslmode=disable&search_path=myschema'
+```
+
+The schema the session is currently using is shown in the status bar. If you don't pin a schema — no `--schema` flag, no `schema` field in the config file and no `search_path` in the URL — you can also change it at any time with <kbd>ctrl+s</kbd> — see [Active schema](#active-schema).
 
 You can use the `--readonly` flag to open a connection in read-only mode. This prevents any write operations (INSERT, UPDATE, DELETE, etc.) from being executed, which is useful when you want to safely browse a production database. The same can be achieved via the configuration file by setting `readonly: true` on a database profile (see [Configuration](#configuration)).
 
@@ -507,7 +513,11 @@ Move around a result set with the arrow keys or <kbd>h</kbd>/<kbd>j</kbd>/<kbd>k
 
 ### Active schema
 
-The right-hand side of the status bar shows the schema the session is currently using, as `active schema: <name>`. On startup that's whatever you passed to `--schema`, or the session default (`current_schema()` on PostgreSQL, `SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')` on Oracle) when the flag is omitted.
+The right-hand side of the status bar shows the schema the session is currently using, as `active schema: <name>`. On startup that's whatever schema you pinned — via `--schema`, the `schema` field in `.dblab.yaml`, or the `search_path` query parameter of a PostgreSQL connection URL — or the session default (`current_schema()` on PostgreSQL, `SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')` on Oracle) when you pinned none.
+
+!!! note
+
+    If you pinned a schema, that's the schema for the whole session and the picker below is disabled: <kbd>ctrl+s</kbd> does nothing. Omit the schema to be able to switch it from the app.
 
 Press <kbd>ctrl+s</kbd> (`schemas`) from any panel to open the schema picker, a filterable list of the schemas the connected user can see. Type to narrow the list, press <kbd>Enter</kbd> to make the highlighted schema the active one, or press <kbd>Esc</kbd> to close the picker without changing anything. Focus returns to the query editor either way.
 
@@ -649,7 +659,7 @@ Applies to all tabs of the result set panel.
 |-----|-------------|--------------|
 | <kbd>Alt+h</kbd>  | Open the query history view | `history` |
 | <kbd>Alt+f</kbd> | Expand the focused query editor or result set panel to full screen | `fullscreen` |
-| <kbd>Ctrl+s</kbd> | Open the schema picker to change the active schema (PostgreSQL and Oracle) | `schemas` |
+| <kbd>Ctrl+s</kbd> | Open the schema picker to change the active schema (PostgreSQL and Oracle, when no schema was pinned at startup) | `schemas` |
 | <kbd>?</kbd> | Open the help modal showing all key bindings | `help` |
 | <kbd>Esc</kbd> | Dismiss the help modal, the query history or the schema picker, exit full-screen mode (or return to normal mode in the query editor) | — |
 | <kbd>Ctrl+c</kbd> | Cancel running queries if any; otherwise quit the application | `quit` |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -131,6 +131,8 @@ dblab --host localhost --user user2 --db FREEPDB1 --pass password --port 1521 --
 dblab --url 'oracle://user2:password@localhost:1521/FREEPDB1' --schema user1
 ```
 
+Whether you pass `--schema` or not, the schema the session is currently using is shown in the status bar and can be changed at any time with <kbd>ctrl+s</kbd> — see [Active schema](#active-schema).
+
 You can use the `--readonly` flag to open a connection in read-only mode. This prevents any write operations (INSERT, UPDATE, DELETE, etc.) from being executed, which is useful when you want to safely browse a production database. The same can be achieved via the configuration file by setting `readonly: true` on a database profile (see [Configuration](#configuration)).
 
 ```{ .sh .copy }
@@ -258,7 +260,7 @@ Bindings are grouped by the part of the UI they belong to, so every panel can be
 
 | Section | What it controls |
 |---------|------------------|
-| `keybindings` (top level) | `help`, `quit`, `history` and `fullscreen`, which are global |
+| `keybindings` (top level) | `help`, `quit`, `history`, `fullscreen` and `schemas`, which are global |
 | `keybindings.navigation` | moving focus between the three panels |
 | `keybindings.editor` | the Vim-style query editor: cursor motion in normal mode, mode switching, and query execution |
 | `keybindings.sidebar` | jumping to the top / bottom of the sidebar tree |
@@ -364,6 +366,8 @@ keybindings:
   quit: 'ctrl+c'
   history: 'alt+h'
   fullscreen: 'alt+f'
+  # opens the active schema picker (postgres and oracle only)
+  schemas: 'ctrl+s'
   # moving focus between the three panels
   navigation:
     up: 'ctrl+k'
@@ -501,6 +505,18 @@ Move around a result set with the arrow keys or <kbd>h</kbd>/<kbd>j</kbd>/<kbd>k
 
     There are no pagination controls — they proved too slow to page through a table effectively. To work through a large table, write a `SELECT` with explicit `OFFSET` and `LIMIT` instead.
 
+### Active schema
+
+The right-hand side of the status bar shows the schema the session is currently using, as `active schema: <name>`. On startup that's whatever you passed to `--schema`, or the session default (`current_schema()` on PostgreSQL, `SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')` on Oracle) when the flag is omitted.
+
+Press <kbd>ctrl+s</kbd> (`schemas`) from any panel to open the schema picker, a filterable list of the schemas the connected user can see. Type to narrow the list, press <kbd>Enter</kbd> to make the highlighted schema the active one, or press <kbd>Esc</kbd> to close the picker without changing anything. Focus returns to the query editor either way.
+
+Switching the active schema changes the database session — `set search_path` on PostgreSQL, `ALTER SESSION SET CURRENT_SCHEMA` on Oracle — so unqualified table names in the queries you execute resolve against the new schema. The sidebar tree is left as it is: it keeps listing the schemas it was built with, and selecting a table there still reads that table's own schema, so browsing the catalog is unaffected.
+
+!!! note
+
+    The schema picker is only available for PostgreSQL and Oracle, the two drivers where dblab tracks an active schema. On MySQL, SQLite and SQL Server <kbd>ctrl+s</kbd> does nothing and the status bar has no schema segment.
+
 ### Full-screen mode
 
 Focus the query editor or the result set panel and press <kbd>alt+f</kbd> (`fullscreen`) to expand it to fill the entire terminal, hiding the title, status bar and the other panels. Press <kbd>Esc</kbd> to return to the split layout. Full-screen mode is also left automatically if you navigate focus away from the editor or result set panel — it isn't available for the sidebar tree.
@@ -549,7 +565,7 @@ While a batch is running, press <kbd>Ctrl+c</kbd> to cancel it; press <kbd>Ctrl+
 
 ![dblab](https://raw.githubusercontent.com/danvergara/dblab/main/assets/tutorials/images/query-history.png){ width="400" : .center }
 
-dblab automatically saves every executed query to a local history file (`$XDG_CONFIG_HOME/dblab/dblab.gob`). Press <kbd>F8</kbd> to open the query history view, which displays past queries sorted newest-first in a filterable list. Use the built-in search to narrow results, press <kbd>Enter</kbd> to load the selected query back into the editor, or press <kbd>Esc</kbd> to return without selecting anything.
+dblab automatically saves every executed query to a local history file (`$XDG_CONFIG_HOME/dblab/dblab.gob`). Press <kbd>alt+h</kbd> to open the query history view, which displays past queries sorted newest-first in a filterable list. Use the built-in search to narrow results, press <kbd>Enter</kbd> to load the selected query back into the editor, or press <kbd>Esc</kbd> to return without selecting anything.
 
 ## Help modal
 
@@ -633,6 +649,7 @@ Applies to all tabs of the result set panel.
 |-----|-------------|--------------|
 | <kbd>Alt+h</kbd>  | Open the query history view | `history` |
 | <kbd>Alt+f</kbd> | Expand the focused query editor or result set panel to full screen | `fullscreen` |
+| <kbd>Ctrl+s</kbd> | Open the schema picker to change the active schema (PostgreSQL and Oracle) | `schemas` |
 | <kbd>?</kbd> | Open the help modal showing all key bindings | `help` |
-| <kbd>Esc</kbd> | Dismiss the help modal or query history, exit full-screen mode (or return to normal mode in the query editor) | — |
+| <kbd>Esc</kbd> | Dismiss the help modal, the query history or the schema picker, exit full-screen mode (or return to normal mode in the query editor) | — |
 | <kbd>Ctrl+c</kbd> | Cancel running queries if any; otherwise quit the application | `quit` |

--- a/pkg/bubbletui/bubbletui.go
+++ b/pkg/bubbletui/bubbletui.go
@@ -194,7 +194,7 @@ func NewModel(c *client.Client, km keys.KeyMap) (*Model, error) {
 		sidebarViewport: svp,
 		resulstset:      NewResultSet(km.ResultSet),
 		help:            h,
-		statusBar:       NewStatusBar(editor.mode, km, c.Driver(), c.Conn()),
+		statusBar:       NewStatusBar(editor.mode, km, c.Driver(), c.Conn(), c.Schema()),
 		schemas:         NewSchemaModel(c),
 		renderedTitle:   dblabTitle,
 		titleHeight:     lipgloss.Height(dblabTitle),
@@ -355,7 +355,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.resulstset, cmd = m.resulstset.Update(msg)
 		cmds = append(cmds, cmd)
 	case schemaSelectedMsg:
+		m.focus = focusEditor
+		m.editor.Focus()
 		m.statusBar.SetSchema(msg.Name)
+		m.applySizes()
+		m.editor, cmd = m.editor.Update(msg)
+		cmds = append(cmds, cmd)
 	case querySelectedMsg, queryHistoryErrMsg, backToNormalMsg:
 		m.focus = focusEditor
 		m.resulstset.Blur()

--- a/pkg/bubbletui/bubbletui.go
+++ b/pkg/bubbletui/bubbletui.go
@@ -267,14 +267,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.toggleFullScreen()
 			}
 		case key.Matches(msg, m.keyMap.Schemas):
-			switch m.c.Driver() {
-			case drivers.PostgreSQL, drivers.Postgres, drivers.PostgresSSH, drivers.Oracle:
-				m.focus = focusSchemas
-				m.schemas.state = stateLoading
-				cmd = m.schemas.Init()
-				cmds = append(cmds, cmd)
-			default:
-				return m, nil
+			if !m.c.DefaultSchemaSelected() {
+				switch m.c.Driver() {
+				case drivers.PostgreSQL, drivers.Postgres, drivers.PostgresSSH, drivers.Oracle:
+					m.focus = focusSchemas
+					m.schemas.state = stateLoading
+					cmd = m.schemas.Init()
+					cmds = append(cmds, cmd)
+				default:
+					return m, nil
+				}
 			}
 		case key.Matches(msg, m.keyMap.Navigation.Right):
 			if m.focus == focusList {
@@ -355,19 +357,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.resulstset, cmd = m.resulstset.Update(msg)
 		cmds = append(cmds, cmd)
 	case schemaSelectedMsg:
-		m.focus = focusEditor
-		m.editor.Focus()
+		m.backToNormal()
 		m.statusBar.SetSchema(msg.Name)
-		m.applySizes()
 		m.editor, cmd = m.editor.Update(msg)
 		cmds = append(cmds, cmd)
 	case querySelectedMsg, queryHistoryErrMsg, backToNormalMsg:
-		m.focus = focusEditor
-		m.resulstset.Blur()
-		m.sidebarViewport.selected = false
-		m.editor.Focus()
+		m.backToNormal()
 		m.editor, cmd = m.editor.Update(msg)
-		m.applySizes()
 		cmds = append(cmds, cmd)
 	}
 
@@ -390,6 +386,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, tea.Batch(cmds...)
+}
+
+func (m *Model) backToNormal() {
+	m.focus = focusEditor
+	m.resulstset.Blur()
+	m.sidebarViewport.selected = false
+	m.editor.Focus()
+	m.applySizes()
 }
 
 func (m Model) View() tea.View {

--- a/pkg/bubbletui/bubbletui.go
+++ b/pkg/bubbletui/bubbletui.go
@@ -46,6 +46,7 @@ const (
 	focusTable
 	focusHistory
 	focusHelp
+	focusSchemas
 )
 
 func (f focusState) String() string {
@@ -123,6 +124,7 @@ type Model struct {
 	queryHistory    *HistoryModel
 	help            help.Model
 	statusBar       StatusBar
+	schemas         *SchemaModel
 
 	// Manages the focus on the app.
 	focus focusState
@@ -193,6 +195,7 @@ func NewModel(c *client.Client, km keys.KeyMap) (*Model, error) {
 		resulstset:      NewResultSet(km.ResultSet),
 		help:            h,
 		statusBar:       NewStatusBar(editor.mode, km, c.Driver(), c.Conn()),
+		schemas:         NewSchemaModel(c),
 		renderedTitle:   dblabTitle,
 		titleHeight:     lipgloss.Height(dblabTitle),
 		dump:            dump,
@@ -262,6 +265,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, m.keyMap.FullScreen):
 			if !m.fullScreen {
 				m.toggleFullScreen()
+			}
+		case key.Matches(msg, m.keyMap.Schemas):
+			switch m.c.Driver() {
+			case drivers.PostgreSQL, drivers.Postgres, drivers.PostgresSSH, drivers.Oracle:
+				m.focus = focusSchemas
+				m.schemas.state = stateLoading
+				cmd = m.schemas.Init()
+				cmds = append(cmds, cmd)
+			default:
+				return m, nil
 			}
 		case key.Matches(msg, m.keyMap.Navigation.Right):
 			if m.focus == focusList {
@@ -341,6 +354,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, cmd)
 		m.resulstset, cmd = m.resulstset.Update(msg)
 		cmds = append(cmds, cmd)
+	case schemaSelectedMsg:
+		m.statusBar.SetSchema(msg.Name)
 	case querySelectedMsg, queryHistoryErrMsg, backToNormalMsg:
 		m.focus = focusEditor
 		m.resulstset.Blur()
@@ -364,6 +379,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case focusHistory:
 		m.queryHistory, cmd = m.queryHistory.Update(msg)
 		cmds = append(cmds, cmd)
+	case focusSchemas:
+		m.schemas, cmd = m.schemas.Update(msg)
+		cmds = append(cmds, cmd)
 	}
 
 	return m, tea.Batch(cmds...)
@@ -378,6 +396,8 @@ func (m Model) View() tea.View {
 		v.SetContent(m.queryHistory.View().Content)
 	case focusHelp:
 		v.SetContent(setModalContent(m.help.View(m.keyMap), m.width, m.height))
+	case focusSchemas:
+		v.SetContent(m.schemas.View().Content)
 	default:
 		if m.fullScreen {
 			v.SetContent(m.fullScreenView())
@@ -445,6 +465,12 @@ func (m *Model) Run() error {
 	}
 
 	return nil
+}
+
+func (m *Model) setSchema(schema string) tea.Cmd {
+	return func() tea.Msg {
+		return nil
+	}
 }
 
 // runTableMetadata gets the given table's metadata asynchronously.
@@ -545,6 +571,7 @@ func (m *Model) applySizes() {
 func (m *Model) fullScreenSizes() {
 	m.help.SetWidth(m.width)
 	m.queryHistory.SetSize(m.width, m.height)
+	m.schemas.SetSize(m.width, m.height)
 	m.statusBar.SetWidth(m.width)
 
 	switch m.focus {
@@ -585,6 +612,7 @@ func (m *Model) defaultSizes() {
 	m.sidebarViewport.SetSize(m.sidebarViewportWidth, m.sidebarViewportHeight)
 	m.resulstset.SetSize(m.resultSetWidth, m.resultSetHeight)
 	m.queryHistory.SetSize(m.width, m.height)
+	m.schemas.SetSize(m.width, m.height)
 	m.statusBar.SetWidth(m.width)
 }
 

--- a/pkg/bubbletui/bubbletui.go
+++ b/pkg/bubbletui/bubbletui.go
@@ -611,6 +611,8 @@ func prepareQueriesForExecution(rawText string) []string {
 	return validQueries
 }
 
+// setModalContent places a text block vertically in a styled box.
+// Receives the content as string and the dimensions as integers.
 func setModalContent(content string, width, height int) string {
 	formStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).

--- a/pkg/bubbletui/bubbletui.go
+++ b/pkg/bubbletui/bubbletui.go
@@ -472,12 +472,6 @@ func (m *Model) Run() error {
 	return nil
 }
 
-func (m *Model) setSchema(schema string) tea.Cmd {
-	return func() tea.Msg {
-		return nil
-	}
-}
-
 // runTableMetadata gets the given table's metadata asynchronously.
 // If the query succeeds, it returns metadataSucessMsg with the metadata,
 // otherwise it returns metadataErrMsg with the error.

--- a/pkg/bubbletui/keys/keys.go
+++ b/pkg/bubbletui/keys/keys.go
@@ -57,12 +57,12 @@ func ReadKeyMapFromConfig() (KeyMap, error) {
 		Quit:       key.NewBinding(key.WithKeys(cfg.KeyBindings.Quit), key.WithHelp(cfg.KeyBindings.Quit, "quit")),
 		FullScreen: key.NewBinding(key.WithKeys(cfg.KeyBindings.FullScreen), key.WithHelp(cfg.KeyBindings.FullScreen, "fullscreen focus")),
 		History:    key.NewBinding(key.WithKeys(cfg.KeyBindings.History), key.WithHelp(cfg.KeyBindings.History, "query history")),
-		Schemas:    key.NewBinding(key.WithKeys(cfg.KeyBindings.Schemas), key.WithHelp(cfg.KeyBindings.Schemas, "database schemas available for the user")),
+		Schemas:    key.NewBinding(key.WithKeys(cfg.KeyBindings.Schemas), key.WithHelp(cfg.KeyBindings.Schemas, "pick the active database schema")),
 		Navigation: NavigationKeyMap{
-			Up:    key.NewBinding(key.WithKeys(cfg.KeyBindings.Navigation.Up), key.WithHelp(cfg.KeyBindings.Navigation.Up, "Toggle to the panel above")),
-			Down:  key.NewBinding(key.WithKeys(cfg.KeyBindings.Navigation.Down), key.WithHelp(cfg.KeyBindings.Navigation.Down, "Toggle to the panel below")),
-			Left:  key.NewBinding(key.WithKeys(cfg.KeyBindings.Navigation.Left), key.WithHelp(cfg.KeyBindings.Navigation.Left, "Toggle to the panel on the left")),
-			Right: key.NewBinding(key.WithKeys(cfg.KeyBindings.Navigation.Right), key.WithHelp(cfg.KeyBindings.Navigation.Right, "Toggle to the panel on the right")),
+			Up:    key.NewBinding(key.WithKeys(cfg.KeyBindings.Navigation.Up), key.WithHelp(cfg.KeyBindings.Navigation.Up, "toggle to the panel above")),
+			Down:  key.NewBinding(key.WithKeys(cfg.KeyBindings.Navigation.Down), key.WithHelp(cfg.KeyBindings.Navigation.Down, "toggle to the panel below")),
+			Left:  key.NewBinding(key.WithKeys(cfg.KeyBindings.Navigation.Left), key.WithHelp(cfg.KeyBindings.Navigation.Left, "toggle to the panel on the left")),
+			Right: key.NewBinding(key.WithKeys(cfg.KeyBindings.Navigation.Right), key.WithHelp(cfg.KeyBindings.Navigation.Right, "toggle to the panel on the right")),
 		},
 		Editor: EditorKeyMap{
 			Up:                 key.NewBinding(key.WithKeys(cfg.KeyBindings.Editor.Up), key.WithHelp(cfg.KeyBindings.Editor.Up, "move up (editor)")),
@@ -104,7 +104,7 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 		{k.Sidebar.GoToBottom, k.Sidebar.GoToTop},
 		{k.ResultSet.NextTab, k.ResultSet.PrevTab, k.ResultSet.LineStart, k.ResultSet.LineEnd, k.ResultSet.GoToTop, k.ResultSet.GoToBottom, k.Editor.ExecuteQuery, k.Editor.ExecuteSingleQuery},
 		{k.Editor.Up, k.Editor.Down, k.Editor.Left, k.Editor.Right, k.Editor.Insert, k.Editor.Normal, k.Editor.GoToBottom, k.Editor.GoToTop},
-		{k.Editor.LineStart, k.Editor.LineEnd, k.Navigation.Up, k.Navigation.Down, k.Navigation.Left, k.Navigation.Right, k.FullScreen, k.Help, k.Quit},
+		{k.Editor.LineStart, k.Editor.LineEnd, k.Navigation.Up, k.Navigation.Down, k.Navigation.Left, k.Navigation.Right, k.FullScreen, k.Schemas, k.Help, k.Quit},
 	}
 }
 

--- a/pkg/bubbletui/keys/keys.go
+++ b/pkg/bubbletui/keys/keys.go
@@ -10,6 +10,7 @@ type KeyMap struct {
 	Quit       key.Binding
 	History    key.Binding
 	FullScreen key.Binding
+	Schemas    key.Binding
 	Navigation NavigationKeyMap
 	Editor     EditorKeyMap
 	Sidebar    SidebarKeyMap
@@ -34,6 +35,10 @@ func DefaultKeyMap() KeyMap {
 			key.WithKeys("alt+f"),
 			key.WithHelp("alt+f", "fullscreen focus"),
 		),
+		Schemas: key.NewBinding(
+			key.WithKeys("ctrl+s"),
+			key.WithHelp("ctrl+s", "database schemas available for the current user"),
+		),
 		Navigation: DefaultNavitationKeyMap(),
 		Editor:     DefaultEditorKeyMap(),
 		Sidebar:    DefaultSidebarKeyMap(),
@@ -52,6 +57,7 @@ func ReadKeyMapFromConfig() (KeyMap, error) {
 		Quit:       key.NewBinding(key.WithKeys(cfg.KeyBindings.Quit), key.WithHelp(cfg.KeyBindings.Quit, "quit")),
 		FullScreen: key.NewBinding(key.WithKeys(cfg.KeyBindings.FullScreen), key.WithHelp(cfg.KeyBindings.FullScreen, "fullscreen focus")),
 		History:    key.NewBinding(key.WithKeys(cfg.KeyBindings.History), key.WithHelp(cfg.KeyBindings.History, "query history")),
+		Schemas:    key.NewBinding(key.WithKeys(cfg.KeyBindings.Schemas), key.WithHelp(cfg.KeyBindings.Schemas, "database schemas available for the user")),
 		Navigation: NavigationKeyMap{
 			Up:    key.NewBinding(key.WithKeys(cfg.KeyBindings.Navigation.Up), key.WithHelp(cfg.KeyBindings.Navigation.Up, "Toggle to the panel above")),
 			Down:  key.NewBinding(key.WithKeys(cfg.KeyBindings.Navigation.Down), key.WithHelp(cfg.KeyBindings.Navigation.Down, "Toggle to the panel below")),

--- a/pkg/bubbletui/schema.go
+++ b/pkg/bubbletui/schema.go
@@ -2,15 +2,21 @@ package bubbletui
 
 import (
 	"context"
+	"fmt"
 
 	"charm.land/bubbles/v2/list"
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/danvergara/dblab/pkg/client"
 )
 
 type schemaLoadedMsg struct {
 	items []list.Item
+}
+
+type schemaSelectedMsg struct {
+	Name string
 }
 
 type errSchemasMsg struct{ err error }
@@ -25,21 +31,140 @@ func (d dbSchema) Description() string { return "" }
 func (d dbSchema) FilterValue() string { return d.name }
 
 type SchemaModel struct {
+	// checks if the schema list is loading or ready to show.
+	state state
 	// spinner model to show while the data is loading.
 	spinner spinner.Model
 	// list model to show the query history.
 	list list.Model
-	c    *client.Client
+	// database client.
+	c *client.Client
+	// model size.
+	width         int
+	height        int
+	loadingAction string
+}
+
+func NewSchemaModel(c *client.Client) *SchemaModel {
+	delegate := list.NewDefaultDelegate()
+
+	// white text for the normal title.
+	delegate.Styles.NormalTitle = delegate.Styles.NormalTitle.
+		Foreground(whiteText)
+
+	// Cyber green color for the selected items with a magent border foreground.
+	delegate.Styles.SelectedTitle = delegate.Styles.SelectedTitle.
+		Foreground(cyberGreen).
+		BorderLeftForeground(hiMagenta)
+
+	schemaList := list.New([]list.Item{}, delegate, 0, 0)
+
+	schemaList.Title = "Select the current schema"
+	schemaList.Styles.Title = schemaList.Styles.Title.
+		Background(darkPurple).
+		Foreground(hiMagenta).
+		Bold(true)
+	schemaList.SetShowStatusBar(false)
+	schemaList.SetShowHelp(true)
+	schemaList.KeyMap.Quit.Unbind()
+	schemaList.KeyMap.ForceQuit.Unbind()
+
+	// Set up the spinner model.
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+
+	return &SchemaModel{
+		state:         stateLoading,
+		spinner:       s,
+		c:             c,
+		list:          schemaList,
+		loadingAction: "Fetch schemas from the database...",
+	}
+}
+
+// SetSize method is used to set the model size when the main tui model routes the size from the tea.WindowSizeMsg message to this model.
+func (s *SchemaModel) SetSize(width, height int) {
+	s.height = height
+	s.width = width
+	s.list.SetSize(s.width-6, 14)
 }
 
 // Init method is used to initialize the spinner Tick command and fetch the query history.
-func (h *SchemaModel) Init() tea.Cmd {
-	return tea.Batch(h.spinner.Tick, fetchSchemasCmd(h.c))
+func (s *SchemaModel) Init() tea.Cmd {
+	return tea.Batch(s.spinner.Tick, s.fetchSchemasCmd())
 }
 
-func fetchSchemasCmd(c *client.Client) tea.Cmd {
+// Update method is used to keep elm cycle going for the schema model.
+func (s *SchemaModel) Update(msg tea.Msg) (*SchemaModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		s.width = msg.Width
+		s.height = msg.Height
+		s.list.SetSize(s.width-6, 14)
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "enter":
+			selectedSchema := s.list.SelectedItem().(dbSchema).name
+			return s, s.setSchema(selectedSchema)
+		case "esc":
+			// Press esc to get back to the main app if a query was not selected.
+			return s, func() tea.Msg {
+				return backToNormalMsg{}
+			}
+		}
+	case schemaLoadedMsg:
+		cmd := s.list.SetItems(msg.items)
+		s.state = stateForm
+		return s, cmd
+	}
+
+	switch s.state {
+	case stateLoading:
+		var cmd tea.Cmd
+		s.spinner, cmd = s.spinner.Update(msg)
+		return s, cmd
+
+	case stateForm:
+		var cmd tea.Cmd
+		s.list, cmd = s.list.Update(msg)
+		return s, cmd
+	}
+
+	return s, nil
+}
+
+func (s *SchemaModel) View() tea.View {
+	var (
+		v       tea.View
+		content string
+	)
+	v.AltScreen = true
+
+	switch s.state {
+	case stateLoading:
+		spinnerView := fmt.Sprintf("\n %s %s\n", s.spinner.View(), s.loadingAction)
+		content = lipgloss.Place(s.width, s.height, lipgloss.Center, lipgloss.Center, spinnerView)
+	case stateForm:
+		content = setModalContent(s.list.View(), s.width, s.height)
+	}
+
+	v.SetContent(content)
+	return v
+}
+
+func (s *SchemaModel) setSchema(schema string) tea.Cmd {
 	return func() tea.Msg {
-		schemas, err := c.Schemas(context.Background())
+		if err := s.c.SetActiveSchema(context.Background(), schema); err != nil {
+			return errSchemasMsg{err: err}
+		}
+
+		return schemaSelectedMsg{Name: schema}
+	}
+}
+
+func (s *SchemaModel) fetchSchemasCmd() tea.Cmd {
+	return func() tea.Msg {
+		schemas, err := s.c.Schemas(context.Background())
 		if err != nil {
 			return errSchemasMsg{err: err}
 		}

--- a/pkg/bubbletui/schema.go
+++ b/pkg/bubbletui/schema.go
@@ -47,6 +47,7 @@ type SchemaModel struct {
 
 func NewSchemaModel(c *client.Client) *SchemaModel {
 	delegate := list.NewDefaultDelegate()
+	delegate.ShowDescription = false
 
 	// white text for the normal title.
 	delegate.Styles.NormalTitle = delegate.Styles.NormalTitle.

--- a/pkg/bubbletui/schema.go
+++ b/pkg/bubbletui/schema.go
@@ -1,0 +1,54 @@
+package bubbletui
+
+import (
+	"context"
+
+	"charm.land/bubbles/v2/list"
+	"charm.land/bubbles/v2/spinner"
+	tea "charm.land/bubbletea/v2"
+	"github.com/danvergara/dblab/pkg/client"
+)
+
+type schemaLoadedMsg struct {
+	items []list.Item
+}
+
+type errSchemasMsg struct{ err error }
+
+type dbSchema struct {
+	name string
+}
+
+// Implement the list.Item interface.
+func (d dbSchema) Title() string       { return d.name }
+func (d dbSchema) Description() string { return "" }
+func (d dbSchema) FilterValue() string { return d.name }
+
+type SchemaModel struct {
+	// spinner model to show while the data is loading.
+	spinner spinner.Model
+	// list model to show the query history.
+	list list.Model
+	c    *client.Client
+}
+
+// Init method is used to initialize the spinner Tick command and fetch the query history.
+func (h *SchemaModel) Init() tea.Cmd {
+	return tea.Batch(h.spinner.Tick, fetchSchemasCmd(h.c))
+}
+
+func fetchSchemasCmd(c *client.Client) tea.Cmd {
+	return func() tea.Msg {
+		schemas, err := c.Schemas(context.Background())
+		if err != nil {
+			return errSchemasMsg{err: err}
+		}
+
+		var items []list.Item
+		for _, s := range schemas {
+			items = append(items, dbSchema{name: s})
+		}
+
+		return schemaLoadedMsg{items: items}
+	}
+}

--- a/pkg/bubbletui/status_bar.go
+++ b/pkg/bubbletui/status_bar.go
@@ -22,7 +22,7 @@ type StatusBar struct {
 	focus  focusState
 }
 
-func NewStatusBar(mode Mode, km keys.KeyMap, driver, conn string) StatusBar {
+func NewStatusBar(mode Mode, km keys.KeyMap, driver, conn, schema string) StatusBar {
 	var statusKb = lipgloss.NewStyle().
 		Background(KbOddBg).
 		Foreground(KbOddText).
@@ -41,7 +41,7 @@ func NewStatusBar(mode Mode, km keys.KeyMap, driver, conn string) StatusBar {
 		lipgloss.NewStyle().
 			Foreground(KbEvenText).
 			Render("  "+driver+": "+conn)
-	return StatusBar{mode: mode, keyMap: km, fixed: statusKb, focus: focusEditor}
+	return StatusBar{mode: mode, keyMap: km, fixed: statusKb, focus: focusEditor, schema: schema}
 }
 
 func (f StatusBar) Init() tea.Cmd {
@@ -93,7 +93,7 @@ func (f StatusBar) View() tea.View {
 		rightBlock =
 			lipgloss.NewStyle().
 				Foreground(KbEvenText).
-				Render("current schema:" + " ")
+				Render("active schema:" + " ")
 	}
 	rightBlock += lipgloss.NewStyle().
 		Foreground(InsertModeBg).

--- a/pkg/bubbletui/status_bar.go
+++ b/pkg/bubbletui/status_bar.go
@@ -18,6 +18,7 @@ type StatusBar struct {
 	width  int
 	keyMap keys.KeyMap
 	fixed  string
+	schema string
 	focus  focusState
 }
 
@@ -59,6 +60,10 @@ func (f *StatusBar) ShowFocus(focus focusState) {
 	f.focus = focus
 }
 
+func (f *StatusBar) SetSchema(schema string) {
+	f.schema = schema
+}
+
 func (f *StatusBar) SetWidth(width int) {
 	f.width = width - 4
 }
@@ -83,9 +88,19 @@ func (f StatusBar) View() tea.View {
 			Render(endArrow) +
 		f.fixed
 
-	rightBlock := lipgloss.NewStyle().
-		Foreground(FocusBg).
-		Render(startArrow) +
+	var rightBlock string
+	if f.schema != "" {
+		rightBlock =
+			lipgloss.NewStyle().
+				Foreground(KbEvenText).
+				Render("current schema:" + " ")
+	}
+	rightBlock += lipgloss.NewStyle().
+		Foreground(InsertModeBg).
+		Render(f.schema+" ") +
+		lipgloss.NewStyle().
+			Foreground(FocusBg).
+			Render(startArrow) +
 		lipgloss.NewStyle().
 			Bold(true).
 			Background(FocusBg).

--- a/pkg/bubbletui/status_bar_test.go
+++ b/pkg/bubbletui/status_bar_test.go
@@ -12,7 +12,7 @@ func TestModelStatusBarTracksEditorModeChanges(t *testing.T) {
 	c, _ := client.New(command.Options{Driver: "sqlite", Host: "/tmp/file.bd"})
 	km := keys.DefaultKeyMap()
 	editor := NewEditor(km.Editor)
-	m := &Model{editor: editor, statusBar: NewStatusBar(editor.mode, km, c.Driver(), c.Conn())}
+	m := &Model{editor: editor, statusBar: NewStatusBar(editor.mode, km, c.Driver(), c.Conn(), c.Schema())}
 
 	updated, _ := m.Update(modeChangeMsg{mode: InsertMode})
 	model, ok := updated.(Model)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"regexp"
 	"strings"
@@ -80,6 +81,7 @@ type databaseQuerier interface {
 	GetViewDefinition(view ViewRef) (string, []any, error)
 	Schemas() (string, []any, error)
 	SetActiveSchema(schema string) (string, []any, error)
+	GetActiveSchemaQuery() string
 }
 
 // Client is used to store the pool of db connection.
@@ -98,6 +100,8 @@ type Client struct {
 
 // New return an instance of the client.
 func New(opts command.Options) (*Client, error) {
+	ctx := context.Background()
+
 	conn, opts, err := connection.BuildConnectionFromOpts(opts)
 	if err != nil {
 		return nil, err
@@ -140,16 +144,16 @@ func New(opts command.Options) (*Client, error) {
 	}
 
 	if c.schema != "" {
-		switch c.driver {
-		case drivers.PostgreSQL, drivers.Postgres, drivers.PostgresSSH:
-			if _, err = db.Exec(fmt.Sprintf("set search_path = '%s'", c.schema)); err != nil {
-				return nil, err
-			}
-		case drivers.Oracle:
-			if _, err = db.Exec(fmt.Sprintf("ALTER SESSION SET CURRENT_SCHEMA = %s", c.schema)); err != nil {
-				return nil, err
-			}
+		if err := c.SetActiveSchema(ctx, c.schema); err != nil {
+			return nil, err
 		}
+	} else {
+		defaultSchema, err := c.fetchActiveSchema(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		c.schema = defaultSchema
 	}
 
 	if c.readOnly {
@@ -182,6 +186,11 @@ func New(opts command.Options) (*Client, error) {
 	c.paginationManager = pm
 
 	return c, nil
+}
+
+// Schema returns the current active schema.
+func (c *Client) Schema() string {
+	return c.schema
 }
 
 // DB Return the db attribute.
@@ -702,18 +711,25 @@ func (c *Client) Schemas(ctx context.Context) ([]string, error) {
 		schemas = append(schemas, name)
 	}
 
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
 	return schemas, nil
 }
 
 func (c *Client) SetActiveSchema(ctx context.Context, schema string) error {
-	query, args, err := c.databaseQuerier.SetActiveSchema(schema)
-	if err != nil {
+	switch c.driver {
+	case drivers.PostgreSQL, drivers.Postgres, drivers.PostgresSSH, drivers.Oracle:
+		query, args, err := c.databaseQuerier.SetActiveSchema(schema)
+		if err != nil {
+			return err
+		}
+
+		_, err = c.db.ExecContext(ctx, query, args...)
 		return err
 	}
-
-	_, err = c.db.ExecContext(ctx, query, args...)
-	return err
-
+	return nil
 }
 
 func (c *Client) viewDefintion(view ViewRef) ([][]string, []string, error) {
@@ -747,6 +763,25 @@ func (c *Client) isValidJSONColumn(dbTypeName string) bool {
 	}
 }
 
+func (c *Client) fetchActiveSchema(ctx context.Context) (string, error) {
+	switch c.driver {
+	case drivers.PostgreSQL, drivers.Postgres, drivers.PostgresSSH, drivers.Oracle:
+		query := c.databaseQuerier.GetActiveSchemaQuery()
+		var schemaName sql.NullString
+		if err := c.db.GetContext(ctx, &schemaName, query); err != nil {
+			return "", err
+		}
+
+		if schemaName.Valid {
+			return schemaName.String, nil
+		}
+	}
+
+	return "", nil
+}
+
+// func (c *Client) setActive
+//
 // commentRegex matches both single-line (--) and multi-line (/* */) SQL comments.
 var commentRegex = regexp.MustCompile(`(?s)/\*.*?\*/|--.*?\n`)
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -86,16 +86,17 @@ type databaseQuerier interface {
 
 // Client is used to store the pool of db connection.
 type Client struct {
-	db                *sqlx.DB
-	dbName            string
-	databaseQuerier   databaseQuerier
-	user              string
-	port              string
-	driver, schema    string
-	host              string
-	paginationManager *pagination.Manager
-	limit             uint
-	readOnly          bool
+	db                    *sqlx.DB
+	dbName                string
+	databaseQuerier       databaseQuerier
+	user                  string
+	port                  string
+	driver, schema        string
+	defaultSchemaSelected bool
+	host                  string
+	paginationManager     *pagination.Manager
+	limit                 uint
+	readOnly              bool
 }
 
 // New return an instance of the client.
@@ -147,6 +148,7 @@ func New(opts command.Options) (*Client, error) {
 		if err := c.SetActiveSchema(ctx, c.schema); err != nil {
 			return nil, err
 		}
+		c.defaultSchemaSelected = true
 	} else {
 		defaultSchema, err := c.fetchActiveSchema(ctx)
 		if err != nil {
@@ -191,6 +193,11 @@ func New(opts command.Options) (*Client, error) {
 // Schema returns the current active schema.
 func (c *Client) Schema() string {
 	return c.schema
+}
+
+// DefaultSchemaSelected returns if the default schema was selected by  the schema flag.
+func (c *Client) DefaultSchemaSelected() bool {
+	return c.defaultSchemaSelected
 }
 
 // DB Return the db attribute.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -78,7 +78,8 @@ type databaseQuerier interface {
 	Indexes(table TableRef) (string, []any, error)
 	Catalog(context.Context) (*DBNode, error)
 	GetViewDefinition(view ViewRef) (string, []any, error)
-	Schemas(ctx context.Context) ([]string, error)
+	Schemas() (string, []any, error)
+	SetActiveSchema(schema string) (string, []any, error)
 }
 
 // Client is used to store the pool of db connection.
@@ -680,7 +681,39 @@ func (c *Client) Catalog(ctx context.Context) (*DBNode, error) {
 }
 
 func (c *Client) Schemas(ctx context.Context) ([]string, error) {
-	return c.databaseQuerier.Schemas(ctx)
+	query, args, err := c.databaseQuerier.Schemas()
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := c.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	schemas := make([]string, 0)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+
+		schemas = append(schemas, name)
+	}
+
+	return schemas, nil
+}
+
+func (c *Client) SetActiveSchema(ctx context.Context, schema string) error {
+	query, args, err := c.databaseQuerier.SetActiveSchema(schema)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.db.ExecContext(ctx, query, args...)
+	return err
+
 }
 
 func (c *Client) viewDefintion(view ViewRef) ([][]string, []string, error) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -78,6 +78,7 @@ type databaseQuerier interface {
 	Indexes(table TableRef) (string, []any, error)
 	Catalog(context.Context) (*DBNode, error)
 	GetViewDefinition(view ViewRef) (string, []any, error)
+	Schemas(ctx context.Context) ([]string, error)
 }
 
 // Client is used to store the pool of db connection.
@@ -676,6 +677,10 @@ func (c *Client) indexes(table TableRef) ([][]string, []string, error) {
 
 func (c *Client) Catalog(ctx context.Context) (*DBNode, error) {
 	return c.databaseQuerier.Catalog(ctx)
+}
+
+func (c *Client) Schemas(ctx context.Context) ([]string, error) {
+	return c.databaseQuerier.Schemas(ctx)
 }
 
 func (c *Client) viewDefintion(view ViewRef) ([][]string, []string, error) {

--- a/pkg/client/mssql.go
+++ b/pkg/client/mssql.go
@@ -322,3 +322,5 @@ func (m *mssql) Schemas() (string, []any, error) {
 func (m *mssql) SetActiveSchema(schema string) (string, []any, error) {
 	return "", nil, errors.New("schemas not supported")
 }
+
+func (m *mssql) GetActiveSchemaQuery() string { return "" }

--- a/pkg/client/mssql.go
+++ b/pkg/client/mssql.go
@@ -311,3 +311,7 @@ func (m *mssql) fetchViews(_ context.Context, parentName, parentID string) ([]*D
 
 	return views, nil
 }
+
+func (m *mssql) Schemas(ctx context.Context) ([]string, error) {
+	return nil, nil
+}

--- a/pkg/client/mssql.go
+++ b/pkg/client/mssql.go
@@ -2,10 +2,18 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/jmoiron/sqlx"
+)
+
+var (
+	mssqlSchemasQuery = sq.Select("s.name").
+		From("sys.schemas AS s").
+		Join("sys.database_principals p ON s.principal_id = p.principal_id").
+		PlaceholderFormat(sq.AtP)
 )
 
 // mssql struct is in charge of perform all the SQL Server related queries.
@@ -190,12 +198,7 @@ func (m *mssql) GetViewDefinition(view ViewRef) (string, []any, error) {
 
 // fetchSchemas method lists all the schemas of the current database.
 func (m *mssql) fetchSchemas(_ context.Context, parentID string) ([]*DBNode, error) {
-	query, args, err := sq.Select("s.name").
-		From("sys.schemas AS s").
-		Join("sys.database_principals p ON s.principal_id = p.principal_id").
-		OrderBy("s.name").
-		PlaceholderFormat(sq.AtP).
-		ToSql()
+	query, args, err := mssqlSchemasQuery.ToSql()
 	if err != nil {
 		return nil, err
 	}
@@ -312,6 +315,10 @@ func (m *mssql) fetchViews(_ context.Context, parentName, parentID string) ([]*D
 	return views, nil
 }
 
-func (m *mssql) Schemas(ctx context.Context) ([]string, error) {
-	return nil, nil
+func (m *mssql) Schemas() (string, []any, error) {
+	return "", nil, errors.New("schemas not supported")
+}
+
+func (m *mssql) SetActiveSchema(schema string) (string, []any, error) {
+	return "", nil, errors.New("schemas not supported")
 }

--- a/pkg/client/mysql.go
+++ b/pkg/client/mysql.go
@@ -199,6 +199,10 @@ func (m *mysql) fetchViews(_ context.Context, parentName, parentID string) ([]*D
 	return views, nil
 }
 
-func (m *mysql) Schemas(ctx context.Context) ([]string, error) {
-	return nil, errors.New("schemas not supported")
+func (m *mysql) Schemas() (string, []any, error) {
+	return "", nil, errors.New("schemas not supported")
+}
+
+func (m *mysql) SetActiveSchema(schema string) (string, []any, error) {
+	return "", nil, errors.New("schemas not supported")
 }

--- a/pkg/client/mysql.go
+++ b/pkg/client/mysql.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	sq "github.com/Masterminds/squirrel"
@@ -196,4 +197,8 @@ func (m *mysql) fetchViews(_ context.Context, parentName, parentID string) ([]*D
 	}
 
 	return views, nil
+}
+
+func (m *mysql) Schemas(ctx context.Context) ([]string, error) {
+	return nil, errors.New("schemas not supported")
 }

--- a/pkg/client/mysql.go
+++ b/pkg/client/mysql.go
@@ -115,7 +115,6 @@ func (m *mysql) GetViewDefinition(view ViewRef) (string, []any, error) {
 			"TABLE_NAME":   view.Name,
 		}).
 		ToSql()
-
 	if err != nil {
 		return "", nil, err
 	}
@@ -206,3 +205,5 @@ func (m *mysql) Schemas() (string, []any, error) {
 func (m *mysql) SetActiveSchema(schema string) (string, []any, error) {
 	return "", nil, errors.New("schemas not supported")
 }
+
+func (m *mysql) GetActiveSchemaQuery() string { return "" }

--- a/pkg/client/oracle.go
+++ b/pkg/client/oracle.go
@@ -315,3 +315,7 @@ func (o *oracle) Schemas() (string, []any, error) {
 func (o *oracle) SetActiveSchema(schema string) (string, []any, error) {
 	return fmt.Sprintf("ALTER SESSION SET CURRENT_SCHEMA = %s", schema), nil, nil
 }
+
+func (o *oracle) GetActiveSchemaQuery() string {
+	return "SELECT SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA') FROM DUAL;"
+}

--- a/pkg/client/oracle.go
+++ b/pkg/client/oracle.go
@@ -10,6 +10,14 @@ import (
 	_ "github.com/sijms/go-ora/v2"
 )
 
+var (
+	oracleSchemasQuery = `
+		SELECT DISTINCT owner AS schema_name
+		FROM all_tables
+		ORDER BY owner
+	`
+)
+
 // oracle struct is in charge of perform all the oracle related queries.
 type oracle struct {
 	db     *sqlx.DB
@@ -190,12 +198,7 @@ func (o *oracle) GetViewDefinition(view ViewRef) (string, []any, error) {
 
 // fetchSchemas method lists all the schemas of the current database.
 func (o *oracle) fetchSchemas(_ context.Context, parentID string) ([]*DBNode, error) {
-	query := `
-		SELECT DISTINCT owner AS schema_name
-		FROM all_tables
-		ORDER BY owner
-	`
-	rows, err := o.db.Query(query)
+	rows, err := o.db.Query(oracleSchemasQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -305,6 +308,10 @@ func (o *oracle) fetchViews(_ context.Context, parentName, parentID string) ([]*
 	return views, nil
 }
 
-func (o *oracle) Schemas(ctx context.Context) ([]string, error) {
-	return nil, nil
+func (o *oracle) Schemas() (string, []any, error) {
+	return oracleSchemasQuery, nil, nil
+}
+
+func (o *oracle) SetActiveSchema(schema string) (string, []any, error) {
+	return fmt.Sprintf("ALTER SESSION SET CURRENT_SCHEMA = %s", schema), nil, nil
 }

--- a/pkg/client/oracle.go
+++ b/pkg/client/oracle.go
@@ -304,3 +304,7 @@ func (o *oracle) fetchViews(_ context.Context, parentName, parentID string) ([]*
 
 	return views, nil
 }
+
+func (o *oracle) Schemas(ctx context.Context) ([]string, error) {
+	return nil, nil
+}

--- a/pkg/client/postgres.go
+++ b/pkg/client/postgres.go
@@ -8,14 +8,12 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-var (
-	postgresSchemaQuery = sq.Select("schema_name").
-		From("information_schema.schemata").
-		Where(sq.NotEq{
-			"schema_name ": []string{"information_schema", "pg_catalog"},
-		}).
-		PlaceholderFormat(sq.Dollar)
-)
+var postgresSchemaQuery = sq.Select("schema_name").
+	From("information_schema.schemata").
+	Where(sq.NotEq{
+		"schema_name ": []string{"information_schema", "pg_catalog"},
+	}).
+	PlaceholderFormat(sq.Dollar)
 
 // postgres struct is in charge of perform all the postgres related queries,
 // without the client knowing.
@@ -326,4 +324,8 @@ func (p *postgres) Schemas() (string, []any, error) {
 
 func (p *postgres) SetActiveSchema(schema string) (string, []any, error) {
 	return fmt.Sprintf("set search_path = '%s'", schema), nil, nil
+}
+
+func (p *postgres) GetActiveSchemaQuery() string {
+	return "SELECT current_schema();"
 }

--- a/pkg/client/postgres.go
+++ b/pkg/client/postgres.go
@@ -316,3 +316,7 @@ func (p *postgres) fetchViews(_ context.Context, parentName, parentID string) ([
 
 	return views, nil
 }
+
+func (p *postgres) Schemas(ctx context.Context) ([]string, error) {
+	return nil, nil
+}

--- a/pkg/client/postgres.go
+++ b/pkg/client/postgres.go
@@ -8,6 +8,15 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+var (
+	postgresSchemaQuery = sq.Select("schema_name").
+		From("information_schema.schemata").
+		Where(sq.NotEq{
+			"schema_name ": []string{"information_schema", "pg_catalog"},
+		}).
+		PlaceholderFormat(sq.Dollar)
+)
+
 // postgres struct is in charge of perform all the postgres related queries,
 // without the client knowing.
 type postgres struct {
@@ -191,13 +200,7 @@ func (p *postgres) GetViewDefinition(view ViewRef) (string, []any, error) {
 
 // fetchSchemas method lists all the schemas of the current database.
 func (p *postgres) fetchSchemas(_ context.Context, parentID string) ([]*DBNode, error) {
-	query, args, err := sq.Select("schema_name").
-		From("information_schema.schemata").
-		Where(sq.NotEq{
-			"schema_name ": []string{"information_schema", "pg_catalog"},
-		}).
-		PlaceholderFormat(sq.Dollar).
-		ToSql()
+	query, args, err := postgresSchemaQuery.ToSql()
 	if err != nil {
 		return nil, err
 	}
@@ -317,6 +320,10 @@ func (p *postgres) fetchViews(_ context.Context, parentName, parentID string) ([
 	return views, nil
 }
 
-func (p *postgres) Schemas(ctx context.Context) ([]string, error) {
-	return nil, nil
+func (p *postgres) Schemas() (string, []any, error) {
+	return postgresSchemaQuery.ToSql()
+}
+
+func (p *postgres) SetActiveSchema(schema string) (string, []any, error) {
+	return fmt.Sprintf("set search_path = '%s'", schema), nil, nil
 }

--- a/pkg/client/sqlite.go
+++ b/pkg/client/sqlite.go
@@ -218,3 +218,5 @@ func (s *sqlite) Schemas() (string, []any, error) {
 func (s *sqlite) SetActiveSchema(schema string) (string, []any, error) {
 	return "", nil, errors.New("schemas not supported")
 }
+
+func (s *sqlite) GetActiveSchemaQuery() string { return "" }

--- a/pkg/client/sqlite.go
+++ b/pkg/client/sqlite.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -208,4 +209,8 @@ func (s *sqlite) fetchViews(_ context.Context, parentName, parentID string) ([]*
 	}
 
 	return views, nil
+}
+
+func (s *sqlite) Schemas(ctx context.Context) ([]string, error) {
+	return nil, errors.New("schemas not supported")
 }

--- a/pkg/client/sqlite.go
+++ b/pkg/client/sqlite.go
@@ -211,6 +211,10 @@ func (s *sqlite) fetchViews(_ context.Context, parentName, parentID string) ([]*
 	return views, nil
 }
 
-func (s *sqlite) Schemas(ctx context.Context) ([]string, error) {
-	return nil, errors.New("schemas not supported")
+func (s *sqlite) Schemas() (string, []any, error) {
+	return "", nil, errors.New("schemas not supported")
+}
+
+func (s *sqlite) SetActiveSchema(schema string) (string, []any, error) {
+	return "", nil, errors.New("schemas not supported")
 }

--- a/pkg/config/.dblab.yaml
+++ b/pkg/config/.dblab.yaml
@@ -69,6 +69,7 @@ keybindings:
   quit: 'ctrl+c'
   history: 'alt+h'
   fullscreen: 'alt+f'
+  schemas: 'ctrl+s'
   navigation:
     up: 'ctrl+k'
     down: 'ctrl+j'

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,6 +76,7 @@ type KeyBindings struct {
 	Quit       string `fig:"quit" default:"ctrl+c"`
 	History    string `fig:"history" default:"alt+h"`
 	FullScreen string `fig:"fullscreen" default:"alt+f"`
+	Schemas    string `fig:"schemas" default:"ctrl+s"`
 	Navigation NavigationBindgins
 	Editor     EditorKeyMap
 	Sidebar    SidebarKeyMap

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -186,6 +186,7 @@ func TestSetupKeybindings(t *testing.T) {
 	assert.Contains(t, km.Quit, "ctrl+c")
 	assert.Contains(t, km.History, "alt+h")
 	assert.Contains(t, km.FullScreen, "alt+f")
+	assert.Contains(t, km.FullScreen, "ctrl+s")
 
 	// Navigation.
 	assert.Contains(t, km.Navigation.Up, "ctrl+k")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -186,7 +186,7 @@ func TestSetupKeybindings(t *testing.T) {
 	assert.Contains(t, km.Quit, "ctrl+c")
 	assert.Contains(t, km.History, "alt+h")
 	assert.Contains(t, km.FullScreen, "alt+f")
-	assert.Contains(t, km.FullScreen, "ctrl+s")
+	assert.Contains(t, km.Schemas, "ctrl+s")
 
 	// Navigation.
 	assert.Contains(t, km.Navigation.Up, "ctrl+k")

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -65,7 +65,7 @@ func BuildConnectionFromOpts(opts command.Options) (string, command.Options, err
 				opts.Driver = drivers.Postgres
 			}
 
-			conn, err := formatPostgresURL(opts)
+			conn, opts, err := formatPostgresURL(opts)
 
 			return conn, opts, err
 		}
@@ -288,14 +288,14 @@ func currentUser() (string, error) {
 }
 
 // formatPostgresURL returns valid uri for postgres connection.
-func formatPostgresURL(opts command.Options) (string, error) {
+func formatPostgresURL(opts command.Options) (string, command.Options, error) {
 	if !hasValidPostgresPrefix(opts.URL) {
-		return "", fmt.Errorf("invalid prefix %s : %w", opts.URL, ErrInvalidPostgresURLFormat)
+		return "", opts, fmt.Errorf("invalid prefix %s : %w", opts.URL, ErrInvalidPostgresURLFormat)
 	}
 
 	uri, err := url.Parse(opts.URL)
 	if err != nil {
-		return "", fmt.Errorf("%v : %w", err, ErrInvalidPostgresURLFormat)
+		return "", opts, fmt.Errorf("%v : %w", err, ErrInvalidPostgresURLFormat)
 	}
 
 	result := map[string]string{}
@@ -313,13 +313,17 @@ func formatPostgresURL(opts command.Options) (string, error) {
 		}
 	}
 
+	if result["search_path"] != "" {
+		opts.Schema = result["search_path"]
+	}
+
 	query := url.Values{}
 	for k, v := range result {
 		query.Add(k, v)
 	}
 	uri.RawQuery = query.Encode()
 
-	return uri.String(), nil
+	return uri.String(), opts, nil
 }
 
 // formatMySQLURL returns valid uri for mysql connection.

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -793,12 +793,28 @@ func TestFormatPostgresURL(t *testing.T) {
 				err:      ErrInvalidPostgresURLFormat,
 			},
 		},
+		{
+			name: "valid url with schema",
+			given: given{
+				opts: command.Options{
+					URL: "postgres://user:password@localhost:5432/db?sslmode=disable&search_path=my_schema",
+				},
+			},
+			want: want{
+				uri: "postgres://user:password@localhost:5432/db?search_path=my_schema&sslmode=disable",
+			},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			uri, err := formatPostgresURL(tc.given.opts)
+			var (
+				uri string
+				err error
+			)
+
+			uri, tc.given.opts, err = formatPostgresURL(tc.given.opts)
 
 			if tc.want.hasError {
 				assert.Error(t, err)


### PR DESCRIPTION
# Active Schema Selection

## Description

<img width="509" height="399" alt="Screenshot From 2026-09-02 09-21-36" src="https://github.com/user-attachments/assets/47d50771-d233-4a15-9c21-aafd49db2ddf" />

dblab could already be pointed at a single schema with `--schema` (or the `schema` field in
`.dblab.yaml`), but that choice was fixed for the whole session: there was no way to see which
schema the session was actually using, and no way to change it without restarting the app.

This PR adds a schema picker to the TUI and makes the active schema visible at all times.

- **New schema modal** (`pkg/bubbletui/schema.go`): press <kbd>ctrl+s</kbd> (`keybindings.schemas`)
  to open a filterable list of the schemas the connected user can see. <kbd>Enter</kbd> switches
  the session to the highlighted schema and returns focus to the query editor;
  <kbd>Esc</kbd> dismisses the modal without changing anything. The list is fetched
  asynchronously and shows a spinner while it loads.
- **The status bar shows the active schema** (`pkg/bubbletui/status_bar.go`): it renders
  `active schema: <name>` on the right-hand side, and is updated whenever a new schema is picked.
  When there is no active schema (MySQL, SQLite and SQL Server) the segment is omitted.
- **`--schema` is no longer required to know the schema** (`pkg/client/client.go`): when the flag
  is omitted, the client now queries the session's default schema on connect
  (`current_schema()` on PostgreSQL, `SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')` on Oracle) and
  stores it, so the status bar has something to show from the first frame.
- **Schema handling moved behind the `databaseQuerier` interface**: the interface gained
  `Schemas()`, `SetActiveSchema(schema)` and `GetActiveSchemaQuery()`. The `set search_path` /
  `ALTER SESSION SET CURRENT_SCHEMA` statements that used to be inlined in `client.New()` now
  live in `postgres.go` and `oracle.go`, and `Client.SetActiveSchema` is reused both at connect
  time and by the modal. MySQL, SQLite and SQL Server implement the three methods as
  "not supported".
- **Key binding plumbing**: `schemas` was added to `config.KeyBindings` (default `ctrl+s`),
  to `keys.KeyMap`, to the `FullHelp` rows so it shows up in the <kbd>?</kbd> help modal, and to
  the bundled `.dblab.yaml` examples.

Switching the schema is a session-level change: it affects how unqualified table names in the
query editor resolve. The sidebar tree is not rebuilt, and selecting a table there still queries
that table's own schema, so browsing the catalog is unaffected.

The picker is only wired up for PostgreSQL and Oracle — the two drivers where dblab has a notion
of an active schema. On MySQL, SQLite and SQL Server the key press is a no-op.

Also included, as drive-by cleanups: the repeated schema-listing queries in `postgres.go`,
`oracle.go` and `mssql.go` were hoisted into package-level variables so `fetchSchemas` and the new
`Schemas()` share one definition, and the `Navigation` help strings were lowercased to match the
rest of the key map.

Fixes #346 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
